### PR TITLE
Remove duplicated <path-resolved user-defined type name> rule

### DIFF
--- a/sql-2003-2.bnf
+++ b/sql-2003-2.bnf
@@ -1,7 +1,7 @@
 BNF Grammar for ISO/IEC 9075-2:2003 - Database Language SQL (SQL-2003) SQL/Foundation
 =====================================================================================
 
-@(#)$Id: sql-2003-2.bnf,v 1.20 2017/10/04 14:57:52 jleffler Exp $
+@(#)$Id: sql-2003-2.bnf,v 1.21 2017/10/04 15:15:18 jleffler Exp $
 
 --p
 Information taken from the Final Committee Draft (FCD) of ISO/IEC 9075-2:2003.
@@ -5084,7 +5084,7 @@ NOTE 402 - This statement has no effect on any SQL-transactions subsequent to th
 If an SQL-transaction is currently active, then set the constraint mode for that SQL-transaction in
 the current SQL-session. If no SQL-transaction is currently active, then set the constraint mode for
 the next SQL-transaction in the current SQL-session for the SQL-agent.
-NOTE 404  This statement has no effect on any SQL-transactions subsequent to this SQL-transaction.
+NOTE 404: This statement has no effect on any SQL-transactions subsequent to this SQL-transaction.
 --/p
 
 <set constraints mode statement> ::= SET CONSTRAINTS <constraint name list> { DEFERRED | IMMEDIATE }

--- a/sql-2003-2.bnf
+++ b/sql-2003-2.bnf
@@ -1,7 +1,7 @@
 BNF Grammar for ISO/IEC 9075-2:2003 - Database Language SQL (SQL-2003) SQL/Foundation
 =====================================================================================
 
-@(#)$Id: sql-2003-2.bnf,v 1.19 2016/07/24 15:30:25 jleffler Exp $
+@(#)$Id: sql-2003-2.bnf,v 1.20 2017/10/04 14:57:52 jleffler Exp $
 
 --p
 Information taken from the Final Committee Draft (FCD) of ISO/IEC 9075-2:2003.
@@ -1340,8 +1340,6 @@ grammar.
 <scope clause> ::= SCOPE <table name>
 
 <referenced type> ::= <path-resolved user-defined type name>
-
-<path-resolved user-defined type name> ::= <user-defined type name>
 
 <path-resolved user-defined type name> ::= <user-defined type name>
 
@@ -5086,7 +5084,7 @@ NOTE 402 - This statement has no effect on any SQL-transactions subsequent to th
 If an SQL-transaction is currently active, then set the constraint mode for that SQL-transaction in
 the current SQL-session. If no SQL-transaction is currently active, then set the constraint mode for
 the next SQL-transaction in the current SQL-session for the SQL-agent.
-NOTE 404 – This statement has no effect on any SQL-transactions subsequent to this SQL-transaction.
+NOTE 404 Â– This statement has no effect on any SQL-transactions subsequent to this SQL-transaction.
 --/p
 
 <set constraints mode statement> ::= SET CONSTRAINTS <constraint name list> { DEFERRED | IMMEDIATE }

--- a/sql-2003-2.bnf.html
+++ b/sql-2003-2.bnf.html
@@ -16,9 +16,9 @@
 <br>
 
 <p><font color=green><i><small>
-Derived from file sql-2003-2.bnf version 1.19 dated 2016/07/24 15:30:25
+Derived from file sql-2003-2.bnf version 1.21 dated 2017/10/04 15:15:18
 <br>
-Generated on 2017-01-17 05:18:34+00:00 by file bnf2html.pl version 3.12 dated 2016/04/18 05:13:47
+Generated on 2017-10-04 15:17:56+00:00 by file bnf2html.pl version 3.12 dated 2016/04/18 05:13:47
 </small></i></font></p>
 
 <p>
@@ -739,8 +739,6 @@ grammar.
 <p><a href="#xref-scope clause" name="scope clause"> &lt;scope clause&gt; </a>&nbsp;&nbsp;&nbsp;::=&nbsp;&nbsp; <a href="#xref-SCOPE"> SCOPE </a>  <a href='#table name'>&lt;table name&gt;</a>
 
 <p><a href="#xref-referenced type" name="referenced type"> &lt;referenced type&gt; </a>&nbsp;&nbsp;&nbsp;::=&nbsp;&nbsp; <a href='#path-resolved user-defined type name'>&lt;path-resolved user-defined type name&gt;</a>
-
-<p><a href="#xref-path-resolved user-defined type name" name="path-resolved user-defined type name"> &lt;path-resolved user-defined type name&gt; </a>&nbsp;&nbsp;&nbsp;::=&nbsp;&nbsp; <a href='#user-defined type name'>&lt;user-defined type name&gt;</a>
 
 <p><a href="#xref-path-resolved user-defined type name" name="path-resolved user-defined type name"> &lt;path-resolved user-defined type name&gt; </a>&nbsp;&nbsp;&nbsp;::=&nbsp;&nbsp; <a href='#user-defined type name'>&lt;user-defined type name&gt;</a>
 
@@ -3844,7 +3842,7 @@ NOTE 402 - This statement has no effect on any SQL-transactions subsequent to th
 If an SQL-transaction is currently active, then set the constraint mode for that SQL-transaction in
 the current SQL-session. If no SQL-transaction is currently active, then set the constraint mode for
 the next SQL-transaction in the current SQL-session for the SQL-agent.
-NOTE 404 – This statement has no effect on any SQL-transactions subsequent to this SQL-transaction.
+NOTE 404: This statement has no effect on any SQL-transactions subsequent to this SQL-transaction.
 </p>
 
 <p><a href="#xref-set constraints mode statement" name="set constraints mode statement"> &lt;set constraints mode statement&gt; </a>&nbsp;&nbsp;&nbsp;::=&nbsp;&nbsp; <a href="#xref-SET"> SET </a>  <a href="#xref-CONSTRAINTS"> CONSTRAINTS </a>  <a href='#constraint name list'>&lt;constraint name list&gt;</a>  {  <a href="#xref-DEFERRED"> DEFERRED </a>  |  <a href="#xref-IMMEDIATE"> IMMEDIATE </a>  }
@@ -13085,14 +13083,14 @@ X
           <a href="#object name"> &lt;object name&gt; </a>
      </td>
 </tr>
-<tr> <td>  <a name="xref-double"> </a> double </td>
-     <td> <a href="#C numeric variable"> &lt;C numeric variable&gt; </a>
-     </td>
-</tr>
 <tr> <td>  <a name="xref-DOUBLE"> </a> DOUBLE </td>
      <td> <a href="#approximate numeric type"> &lt;approximate numeric type&gt; </a>
           <a href="#Fortran type specification"> &lt;Fortran type specification&gt; </a>
           <a href="#reserved word"> &lt;reserved word&gt; </a>
+     </td>
+</tr>
+<tr> <td>  <a name="xref-double"> </a> double </td>
+     <td> <a href="#C numeric variable"> &lt;C numeric variable&gt; </a>
      </td>
 </tr>
 <tr> <td>  <a name="xref-DOUBLE_PRECISION"> </a> DOUBLE_PRECISION </td>


### PR DESCRIPTION
As Euan Rochester observed, `sql-2003-2.bnf` contained two copies of the rule for `<path-resolved user-define type name>` where only one is necessary.

Primary fix removes the duplicate.  There was also a stray U+0096 (SPA or 'start of guard area') control character which was replaced by a colon.  The RCS version information was updated too, for better or worse. File `sql-2003-2.bnf.sql` was regenerated from the updated `sql-2003-2.bnf`.
