### PR TITLE
Finish the fix for duplicate rules.

### DIFF
--- a/bnf2html.perl.txt
+++ b/bnf2html.perl.txt
@@ -1,21 +1,42 @@
 #!/usr/bin/env perl
 #
-# @(#)$Id: bnf2html.pl,v 3.12 2016/04/18 05:13:47 jleffler Exp $
+# @(#)$Id: bnf2html.pl,v 3.14 2017/11/13 20:42:26 jleffler Exp $
 #
 # Convert SQL-92, SQL-99 BNF plain text file into hyperlinked HTML.
 
 use strict;
 use warnings;
 use POSIX qw(strftime);
+#use Data::Dumper;
 
 use constant debug => 0;
 
 my(%rules);     # Indexed by rule names w/o angle-brackets; each entry is a ref to a hash.
 my(%keywords);  # Index by keywords; each entry is a ref to a hash.
+my(%names);     # Indexed by rule names w/o angle-brackets; each entry is a ref to an array of line numbers
 
 sub top
 {
 print "<p><a href='#top'>Top</a></p>\n\n";
+}
+
+# Usage: add_rule_name(\%names, $rulename, $.);
+sub add_rule_name
+{
+    my($reflist, $lhs, $line) = @_;
+    #print "\nrulename = $lhs; line = $line\n";
+    if (defined ${$reflist}{$lhs})
+    {
+        #print Data::Dumper->Dump([ ${$reflist}{$lhs} ], qw[ ${$reflist}{$lhs} ]);
+        #print Data::Dumper->Dump([ \@{${$reflist}{$lhs}} ], qw[ \@{${$reflist}{$lhs}} ]);
+        my @lines = @{${$reflist}{$lhs}};
+        print STDERR "\n$0: Rule <$lhs> at line $line already seen at line(s) ", join(", ", @lines), "\n\n";
+    }
+    else
+    {
+        ${$reflist}{$lhs} = [];
+    }
+    push @{${$reflist}{$lhs}}, $line;
 }
 
 # Usage: add_entry(\%keywords, $keyword, $rule);
@@ -169,6 +190,15 @@ sub print_tail
     return($tcount);
 }
 
+sub undo_web_coding
+{
+    my($line) = @_;
+    $line =~ s%&gt;%>%g;
+    $line =~ s%&lt;%<%g;
+    $line =~ s%&amp;%&%g;
+    return $line;
+}
+
 my $hr_count = 0;
 my $tcount = 0;                 # Ick!
 my $def;                        # Current rule
@@ -188,10 +218,15 @@ while (<$WEBCODE>)
     {
         print "<hr>\n";
     }
+    elsif (/^--@@\s*(.*)$/)
+    {
+        my $comment = undo_web_coding($1);
+        print "<!-- $comment -->\n";
+    }
     elsif (/^@.#..Id:/)
     {
         # Convert what(1) string identifier into version information
-        my $id = '$Id: bnf2html.pl,v 3.12 2016/04/18 05:13:47 jleffler Exp $'; 
+        my $id = '$Id: bnf2html.pl,v 3.14 2017/11/13 20:42:26 jleffler Exp $'; 
         my($v1) = rcs_id($_);
         my $v2 = rcs_id($id);
         print "<p><font color=green><i><small>\n";
@@ -201,7 +236,7 @@ while (<$WEBCODE>)
         print "Generated on $today by $v2\n";
         print "</small></i></font></p>\n";
     }
-    elsif (/ ::=/)
+    elsif (/\s+::=/)
     {
         # Definition line
         $def = $_;
@@ -210,6 +245,7 @@ while (<$WEBCODE>)
         $tail =~ s%.*::=\s*%%;
         print qq'<p><a href="#xref-$def" name="$def"> &lt;$def&gt; </a>&nbsp;&nbsp;&nbsp;::=';
         $tcount = 0;
+        add_rule_name(\%names, $def, $.);
         if ($def eq "vertical bar")
         {
             # Needs special case attention to avoid a /* Nothing */ comment appearing.
@@ -244,10 +280,7 @@ while (<$WEBCODE>)
     }
     elsif (m%^--##%)
     {
-        # Undo web-coding
-        s%&gt;%>%g;
-        s%&lt;%<%g;
-        s%&amp;%&%g;
+        $_ = undo_web_coding($_);
         s%^--##\s*%%;
         print "$_\n";
     }
@@ -362,7 +395,7 @@ print "<hr>\n";
 }
 
 printf "%s\n", q'Please send feedback to Jonathan Leffler, variously:';
-printf "%s\n", q'<a href="mailto:jleffler@us.ibm.com"> jleffler@us.ibm.com </a> or';
+printf "%s\n", q'<a href="mailto:jonathan.leffler@hcl.com"> jonathan.leffler@hcl.com </a> or';
 printf "%s\n", q'<a href="mailto:jonathan.leffler@gmail.com"> jonathan.leffler@gmail.com </a>.';
 
 print "\n</body>\n</html>\n";
@@ -427,6 +460,6 @@ Any other line is passed through verbatim.
 
 =head1 AUTHOR
 
-Jonathan Leffler <jleffler@us.ibm.com> <jonathan.leffler@gmail.com>
+Jonathan Leffler <jonathan.leffler@gmail.com>
 
 =cut

--- a/bnf2html.perl.txt
+++ b/bnf2html.perl.txt
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 #
-# @(#)$Id: bnf2html.pl,v 3.14 2017/11/13 20:42:26 jleffler Exp $
+# @(#)$Id: bnf2html.pl,v 3.16 2017/11/14 06:53:22 jleffler Exp $
 #
 # Convert SQL-92, SQL-99 BNF plain text file into hyperlinked HTML.
 
@@ -226,7 +226,7 @@ while (<$WEBCODE>)
     elsif (/^@.#..Id:/)
     {
         # Convert what(1) string identifier into version information
-        my $id = '$Id: bnf2html.pl,v 3.14 2017/11/13 20:42:26 jleffler Exp $'; 
+        my $id = '$Id: bnf2html.pl,v 3.16 2017/11/14 06:53:22 jleffler Exp $';
         my($v1) = rcs_id($_);
         my $v2 = rcs_id($id);
         print "<p><font color=green><i><small>\n";
@@ -353,7 +353,7 @@ foreach my $rule (sort { uc $a cmp uc $b } keys %rules)
         print qq'$pad<a href="#$ref"> &lt;$ref&gt; </a>\n';
         $pad = "          ";
     }
-    print "     </td>\n</tr>\n"; 
+    print "     </td>\n</tr>\n";
 }
 print "</table>\n";
 print "<br>\n";
@@ -386,7 +386,7 @@ foreach my $keyword (sort { uc $a cmp uc $b } keys %keywords)
         print qq'$pad<a href="#$ref"> &lt;$ref&gt; </a>\n';
         $pad = "          ";
     }
-    print "     </td>\n</tr>\n"; 
+    print "     </td>\n</tr>\n";
 }
 print "</table>\n";
 print "<br>\n";
@@ -394,8 +394,7 @@ top;
 print "<hr>\n";
 }
 
-printf "%s\n", q'Please send feedback to Jonathan Leffler, variously:';
-printf "%s\n", q'<a href="mailto:jonathan.leffler@hcl.com"> jonathan.leffler@hcl.com </a> or';
+printf "%s\n", q'Please send feedback to Jonathan Leffler:';
 printf "%s\n", q'<a href="mailto:jonathan.leffler@gmail.com"> jonathan.leffler@gmail.com </a>.';
 
 print "\n</body>\n</html>\n";

--- a/bnf2html.pl
+++ b/bnf2html.pl
@@ -1,21 +1,42 @@
 #!/usr/bin/env perl
 #
-# @(#)$Id: bnf2html.pl,v 3.12 2016/04/18 05:13:47 jleffler Exp $
+# @(#)$Id: bnf2html.pl,v 3.14 2017/11/13 20:42:26 jleffler Exp $
 #
 # Convert SQL-92, SQL-99 BNF plain text file into hyperlinked HTML.
 
 use strict;
 use warnings;
 use POSIX qw(strftime);
+#use Data::Dumper;
 
 use constant debug => 0;
 
 my(%rules);     # Indexed by rule names w/o angle-brackets; each entry is a ref to a hash.
 my(%keywords);  # Index by keywords; each entry is a ref to a hash.
+my(%names);     # Indexed by rule names w/o angle-brackets; each entry is a ref to an array of line numbers
 
 sub top
 {
 print "<p><a href='#top'>Top</a></p>\n\n";
+}
+
+# Usage: add_rule_name(\%names, $rulename, $.);
+sub add_rule_name
+{
+    my($reflist, $lhs, $line) = @_;
+    #print "\nrulename = $lhs; line = $line\n";
+    if (defined ${$reflist}{$lhs})
+    {
+        #print Data::Dumper->Dump([ ${$reflist}{$lhs} ], qw[ ${$reflist}{$lhs} ]);
+        #print Data::Dumper->Dump([ \@{${$reflist}{$lhs}} ], qw[ \@{${$reflist}{$lhs}} ]);
+        my @lines = @{${$reflist}{$lhs}};
+        print STDERR "\n$0: Rule <$lhs> at line $line already seen at line(s) ", join(", ", @lines), "\n\n";
+    }
+    else
+    {
+        ${$reflist}{$lhs} = [];
+    }
+    push @{${$reflist}{$lhs}}, $line;
 }
 
 # Usage: add_entry(\%keywords, $keyword, $rule);
@@ -169,6 +190,15 @@ sub print_tail
     return($tcount);
 }
 
+sub undo_web_coding
+{
+    my($line) = @_;
+    $line =~ s%&gt;%>%g;
+    $line =~ s%&lt;%<%g;
+    $line =~ s%&amp;%&%g;
+    return $line;
+}
+
 my $hr_count = 0;
 my $tcount = 0;                 # Ick!
 my $def;                        # Current rule
@@ -188,10 +218,15 @@ while (<$WEBCODE>)
     {
         print "<hr>\n";
     }
+    elsif (/^--@@\s*(.*)$/)
+    {
+        my $comment = undo_web_coding($1);
+        print "<!-- $comment -->\n";
+    }
     elsif (/^@.#..Id:/)
     {
         # Convert what(1) string identifier into version information
-        my $id = '$Id: bnf2html.pl,v 3.12 2016/04/18 05:13:47 jleffler Exp $'; 
+        my $id = '$Id: bnf2html.pl,v 3.14 2017/11/13 20:42:26 jleffler Exp $'; 
         my($v1) = rcs_id($_);
         my $v2 = rcs_id($id);
         print "<p><font color=green><i><small>\n";
@@ -201,7 +236,7 @@ while (<$WEBCODE>)
         print "Generated on $today by $v2\n";
         print "</small></i></font></p>\n";
     }
-    elsif (/ ::=/)
+    elsif (/\s+::=/)
     {
         # Definition line
         $def = $_;
@@ -210,6 +245,7 @@ while (<$WEBCODE>)
         $tail =~ s%.*::=\s*%%;
         print qq'<p><a href="#xref-$def" name="$def"> &lt;$def&gt; </a>&nbsp;&nbsp;&nbsp;::=';
         $tcount = 0;
+        add_rule_name(\%names, $def, $.);
         if ($def eq "vertical bar")
         {
             # Needs special case attention to avoid a /* Nothing */ comment appearing.
@@ -244,10 +280,7 @@ while (<$WEBCODE>)
     }
     elsif (m%^--##%)
     {
-        # Undo web-coding
-        s%&gt;%>%g;
-        s%&lt;%<%g;
-        s%&amp;%&%g;
+        $_ = undo_web_coding($_);
         s%^--##\s*%%;
         print "$_\n";
     }
@@ -362,7 +395,7 @@ print "<hr>\n";
 }
 
 printf "%s\n", q'Please send feedback to Jonathan Leffler, variously:';
-printf "%s\n", q'<a href="mailto:jleffler@us.ibm.com"> jleffler@us.ibm.com </a> or';
+printf "%s\n", q'<a href="mailto:jonathan.leffler@hcl.com"> jonathan.leffler@hcl.com </a> or';
 printf "%s\n", q'<a href="mailto:jonathan.leffler@gmail.com"> jonathan.leffler@gmail.com </a>.';
 
 print "\n</body>\n</html>\n";
@@ -427,6 +460,6 @@ Any other line is passed through verbatim.
 
 =head1 AUTHOR
 
-Jonathan Leffler <jleffler@us.ibm.com> <jonathan.leffler@gmail.com>
+Jonathan Leffler <jonathan.leffler@gmail.com>
 
 =cut

--- a/bnf2html.pl
+++ b/bnf2html.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 #
-# @(#)$Id: bnf2html.pl,v 3.14 2017/11/13 20:42:26 jleffler Exp $
+# @(#)$Id: bnf2html.pl,v 3.16 2017/11/14 06:53:22 jleffler Exp $
 #
 # Convert SQL-92, SQL-99 BNF plain text file into hyperlinked HTML.
 
@@ -226,7 +226,7 @@ while (<$WEBCODE>)
     elsif (/^@.#..Id:/)
     {
         # Convert what(1) string identifier into version information
-        my $id = '$Id: bnf2html.pl,v 3.14 2017/11/13 20:42:26 jleffler Exp $'; 
+        my $id = '$Id: bnf2html.pl,v 3.16 2017/11/14 06:53:22 jleffler Exp $';
         my($v1) = rcs_id($_);
         my $v2 = rcs_id($id);
         print "<p><font color=green><i><small>\n";
@@ -353,7 +353,7 @@ foreach my $rule (sort { uc $a cmp uc $b } keys %rules)
         print qq'$pad<a href="#$ref"> &lt;$ref&gt; </a>\n';
         $pad = "          ";
     }
-    print "     </td>\n</tr>\n"; 
+    print "     </td>\n</tr>\n";
 }
 print "</table>\n";
 print "<br>\n";
@@ -386,7 +386,7 @@ foreach my $keyword (sort { uc $a cmp uc $b } keys %keywords)
         print qq'$pad<a href="#$ref"> &lt;$ref&gt; </a>\n';
         $pad = "          ";
     }
-    print "     </td>\n</tr>\n"; 
+    print "     </td>\n</tr>\n";
 }
 print "</table>\n";
 print "<br>\n";
@@ -394,8 +394,7 @@ top;
 print "<hr>\n";
 }
 
-printf "%s\n", q'Please send feedback to Jonathan Leffler, variously:';
-printf "%s\n", q'<a href="mailto:jonathan.leffler@hcl.com"> jonathan.leffler@hcl.com </a> or';
+printf "%s\n", q'Please send feedback to Jonathan Leffler:';
 printf "%s\n", q'<a href="mailto:jonathan.leffler@gmail.com"> jonathan.leffler@gmail.com </a>.';
 
 print "\n</body>\n</html>\n";

--- a/bnf2yacc.perl.txt
+++ b/bnf2yacc.perl.txt
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 #
-# @(#)$Id: bnf2yacc.pl,v 1.15 2009/02/02 04:15:04 jleffler Exp $
+# @(#)$Id: bnf2yacc.pl,v 1.16 2017/11/14 06:53:22 jleffler Exp $
 #
 # Convert SQL-92, SQL-99 BNF plain text file into YACC grammar.
 
@@ -378,7 +378,7 @@ sub process_rhs
         }
     }
     print "==== process_rhs: @rule\n" if debug;
-    record_rule($lhs, 0, @rule); 
+    record_rule($lhs, 0, @rule);
     print "<<== process_rhs\n" if debug;
 }
 
@@ -429,7 +429,7 @@ while (<INPUT>)
         elsif (/^--##/)
         {
             print "/* $_ */\n";
-        } 
+        }
         else
         {
             print "/* Unrecognized 2: $_ */\n";

--- a/bnf2yacc.pl
+++ b/bnf2yacc.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 #
-# @(#)$Id: bnf2yacc.pl,v 1.15 2009/02/02 04:15:04 jleffler Exp $
+# @(#)$Id: bnf2yacc.pl,v 1.16 2017/11/14 06:53:22 jleffler Exp $
 #
 # Convert SQL-92, SQL-99 BNF plain text file into YACC grammar.
 
@@ -378,7 +378,7 @@ sub process_rhs
         }
     }
     print "==== process_rhs: @rule\n" if debug;
-    record_rule($lhs, 0, @rule); 
+    record_rule($lhs, 0, @rule);
     print "<<== process_rhs\n" if debug;
 }
 
@@ -429,7 +429,7 @@ while (<INPUT>)
         elsif (/^--##/)
         {
             print "/* $_ */\n";
-        } 
+        }
         else
         {
             print "/* Unrecognized 2: $_ */\n";

--- a/index.html
+++ b/index.html
@@ -1,109 +1,100 @@
+<!-- @(#)$Id: index.html,v 1.9 2017/11/13 20:12:50 jleffler Exp $ -->
+
 <html>
-  <head>
-    <title> BNF Grammars for SQL-92, SQL-99 and SQL-2003 </title>
-  </head>
-  <body bgcolor="WHITE">
-    <h1> BNF Grammars for SQL-92, SQL-99 and SQL-2003 </h1>
-    <h2> SQL-92 </h2>
-    <p>
-      Here is a heavily hyperlinked <a href="sql-92.bnf.html"> HTML </a>
-      version of the BNF grammar for SQL-92 (ISO/IEC 9075:1992 - Database Language - SQL).
-    </p>
-    
-    <p>
-      The <a href="sql-92.bnf"> plain text </a> file from which it was
-      automatically converted is more useful (more legible) for reading
-      without a browser.
-    </p>
-    
-    <h2> SQL-99 </h2>
-    <p>
-      Here is a heavily hyperlinked <a href="sql-99.bnf.html"> HTML </a>
-      version of the BNF grammar for SQL-99 (ISO/IEC 9075-2:1999 - Database
-      Languages - SQL - Part 2: Foundation (SQL/Foundation)).
-    </p>
-    
-    <p>
-      The <a href="sql-99.bnf"> plain text </a> file from which it was
-      automatically converted is more useful (more legible) for reading
-      without a browser.
-    </p>
-    
-    <h2> SQL-2003 </h2>
-    <p>
-      Here is a heavily hyperlinked <a href="sql-2003-2.bnf.html"> HTML </a>
-      version of the BNF grammar for SQL-2003 (ISO/IEC 9075-2:2003 - Database
-      Languages - SQL - Part 2: Foundation (SQL/Foundation)).
-    </p>
-    
-    <p>
-      The <a href="sql-2003-2.bnf"> plain text </a> file from which it was
-      automatically converted is more useful (more legible) for reading
-      without a browser.
-    </p>
-    
-    <p>
-      There is a separate file <a href="sql-2003-1.bnf.html"> HTML </a> for
-      the information from ISO/IEC 9075-1:2003 - Database Languages - SQL -
-      Part 1: Framework (SQL/Framework).
-    </p>
-    <p>
-      It was automatically converted from the <a href="sql-2003-1.bnf"> plain
-      text </a> file, which is more useful (more legible) for reading without
-      a browser.
-    </p>
-    
-    <p>
-      Also available:
-      <bl>
-        <li> <a href="sql-2003-core-features.html"> SQL 2003 Core Features </a> </li>
-        <li> <a href="sql-2003-noncore-features.html"> SQL 2003 Non-Core Features </a> </li>
-      </bl>
-    </p>
-    <h2> Informix OUTER Join Syntax </h2>
-    <p>
-      Here is an <a href="outer-joins.html"> HTML </a> explanation of the
-      Informix OUTER join syntax.
-    </p>
-    
-    <h2> Conversion tools </h2>
-    <p>
-      The plain text <code>.bnf</code> files were converted to HTML by the Perl script
-      <a href="bnf2html.perl.txt"> bnf2html </a> which you may use if you wish.
-      The bnf2html script also uses the C program
-      <a href="webcode-1.09.tgz"> WEBCODE version 1.09 </a>
-      which you can download as a gzipped tar file.
-    </p>
-    
-    <p>
-      See also <a href="bnf2yacc.perl.txt"> bnf2yacc </a>, an experimental
-      script to convert BNF into an outline Yacc grammar.
-      The generated grammar typically includes some unacceptable tokens, such
-      as <i>%token 0</i>, that should be handled by the lexical analyzer
-      rather than the grammar.
-      The SQL standard includes such rules as grammar rules.
-    </p>
-    
-    <p>
-      <i>(The Perl scripts should normally be renamed after downloading.)</i>
-    </p>
-    
-    <h2> Download </h2>
-    <p>
-      You can download a gzipped tar file or a zip file containing the latest version
-      of the raw grammars, the
-      HTML versions of those grammars, and the conversion tools from
-      <a href="https://github.com/ronsavage/SQL/releases/latest"> GitHub </a>.
-    </p>
-    <hr>
-    <p>
-      Please send feedback to Jonathan Leffler
-      (<a href="mailto:jonathan.leffler@gmail.com">jonathan.leffler@gmail.com</a>) <i>and</i>
-      Ron Savage (<a href="mailto:ron@savage.net.au">ron@savage.net.au</a>).
-    </p>
-    
-    <p>
-      Last modified: 13th February 2017
-    </p>
-  </body>
+<head>
+<title> BNF Grammars for SQL-92, SQL-99 and SQL-2003 </title>
+</head>
+
+<body bgcolor="WHITE">
+<h1> BNF Grammars for SQL-92, SQL-99 and SQL-2003 </h1>
+
+<h2> SQL-92 </h2>
+
+Here is a heavily hyperlinked <a href="sql-92.bnf.html"> HTML </a>
+version of the BNF grammar for SQL-92 (ISO/IEC 9075:1992 - Database Language -
+SQL).
+
+The <a href="sql-92.bnf"> plain text </a> file from which it was
+automatically converted is more useful (read legible) for reading
+without a browser.
+
+<h2> SQL-99 </h2>
+
+Here is a heavily hyperlinked <a href="sql-99.bnf.html"> HTML </a>
+version of the BNF grammar for SQL-99 (ISO/IEC 9075-2:1999 - Database
+Languages - SQL - Part 2: Foundation (SQL/Foundation)).
+
+The <a href="sql-99.bnf"> plain text </a> file from which it was
+automatically converted is more useful (read legible) for reading
+without a browser.
+
+<h2> SQL-2003 </h2>
+<p>
+Here is a heavily hyperlinked <a href="sql-2003-2.bnf.html"> HTML </a>
+version of the BNF grammar for SQL-2003 (ISO/IEC 9075-2:2003 - Database
+Languages - SQL - Part 2: Foundation (SQL/Foundation)).
+
+The <a href="sql-2003-2.bnf"> plain text </a> file from which it was
+automatically converted is more useful (read legible) for reading
+without a browser.
+</p>
+
+<p>
+There is a separate file <a href="sql-2003-1.bnf.html"> HTML </a> for
+the information from ISO/IEC 9075-1:2003 - Database Languages - SQL - Part
+1: Framework (SQL/Framework).
+
+It was automatically converted from the <a href="sql-2003-1.bnf"> plain
+text </a> file, which is more useful (read legible) for reading without
+a browser.
+</p>
+
+<p>
+Also available:
+<bl>
+<li> <a href="sql-2003-core-features.html"> SQL 2003 Core Features </a> </li>
+<li> <a href="sql-2003-noncore-features.html"> SQL 2003 Non-Core Features </a> </li>
+</bl>
+
+<h2> Informix OUTER Join Syntax </h2>
+
+Here is an <a href="outer-joins.html"> HTML </a> explanation of the
+Informix OUTER join syntax.
+
+<h2> Conversion tools </h2>
+
+<p>
+The plain text was converted to HTML by the Perl script
+<a href="bnf2html.perl.txt"> bnf2html </a> which you may use if you wish.
+The bnf2html script also uses the C program
+<a href="webcode-1.09.tgz"> WEBCODE version 1.09 </a>
+which you can download as a gzipped tar file.
+</p>
+
+<p>
+See also <a href="bnf2yacc.perl.txt"> bnf2yacc </a>, an experimental
+script to convert BNF into an outline Yacc grammar.
+The generated grammar typically includes some unacceptable tokens, such
+as <i>%token 0</i>, that should be handled by the lexical analyzer
+rather than the grammar.
+The SQL standard includes such rules as grammar rules.
+</p>
+
+<p>
+<i>(The Perl scripts should normally be renamed after downloading.)</i>
+</p>
+
+<h2> Download </h2>
+
+You can download a gzipped tar file containing the raw grammars, the
+HTML versions of those grammars, and the conversion tools as the gzipped
+tar file <a href="sql-bnf.tgz"> sql-bnf.tgz </a>.
+
+<hr>
+Please send feedback to Jonathan Leffler:
+<a href="mailto:jonathan.leffler@gmail.com"> jonathan.leffler@gmail.com </a>.
+<p>
+Last modified:
+13th November 2017
+</body>
 </html>

--- a/outer-joins.html
+++ b/outer-joins.html
@@ -1,4 +1,4 @@
-<!-- @(#)$Id: outer-joins.html,v 1.6 2007/06/14 04:55:07 jleffler Exp $ -->
+<!-- @(#)$Id: outer-joins.html,v 1.7 2017/11/13 20:11:36 jleffler Exp $ -->
 
 <HTML>
 <HEAD>
@@ -1432,9 +1432,9 @@ IBB_Personnel ---- IBB_R_Xxxx ---- IBB_R_Yyyy
 
 <HR>
 Transcribed and annotated by
-<A HREF="mailto:jleffler@us.ibm.com">Jonathan Leffler</A>.
+<A HREF="mailto:jonathan.leffler@gmail.com">Jonathan Leffler</A>.
 <BR>
-Last updated: 2007-01-09
+Last updated: 2017-11-13
 
 </BODY>
 </HTML>

--- a/sql-2003-1.bnf
+++ b/sql-2003-1.bnf
@@ -1,7 +1,7 @@
 BNF Grammar for ISO/IEC 9075-1:2003 SQL/Foundation - Database Language SQL (SQL-2003)
 =====================================================================================
 
-@(#)$Id: sql-2003-1.bnf,v 1.3 2009/06/24 17:15:49 jleffler Exp $
+@(#)$Id: sql-2003-1.bnf,v 1.4 2017/11/14 06:53:22 jleffler Exp $
 
 --p
 Information taken from the Final Committee Draft (FCD) of ISO/IEC 9075-1:2003.
@@ -199,7 +199,7 @@ the SQL object identifier claims to provide the package.
 --h2 Annex B (informative) SQL Packages:
 --/h2
 
---## <table border=1> 
+--## <table border=1>
 --## <tr><td> 1 </td><td> PKG001 </td><td> Enhanced datetime facilities </td></tr>
 --## <tr><td> 2 </td><td> PKG002 </td><td> Enhanced integrity management </td></tr>
 --## <tr><td> 3 </td><td> PKG004 </td><td> PSM </td></tr>

--- a/sql-2003-1.bnf.html
+++ b/sql-2003-1.bnf.html
@@ -18,7 +18,7 @@
 <p><font color=green><i><small>
 Derived from file sql-2003-1.bnf version 1.3 dated 2009/06/24 17:15:49
 <br>
-Generated on 2017-01-17 05:18:34+00:00 by file bnf2html.pl version 3.12 dated 2016/04/18 05:13:47
+Generated on 2017-11-14 05:32:24+00:00 by file bnf2html.pl version 3.14 dated 2017/11/13 20:42:26
 </small></i></font></p>
 
 <p>
@@ -916,7 +916,7 @@ Z
 
 <hr>
 Please send feedback to Jonathan Leffler, variously:
-<a href="mailto:jleffler@us.ibm.com"> jleffler@us.ibm.com </a> or
+<a href="mailto:jonathan.leffler@hcl.com"> jonathan.leffler@hcl.com </a> or
 <a href="mailto:jonathan.leffler@gmail.com"> jonathan.leffler@gmail.com </a>.
 
 </body>

--- a/sql-2003-1.bnf.html
+++ b/sql-2003-1.bnf.html
@@ -16,9 +16,9 @@
 <br>
 
 <p><font color=green><i><small>
-Derived from file sql-2003-1.bnf version 1.3 dated 2009/06/24 17:15:49
+Derived from file sql-2003-1.bnf version 1.4 dated 2017/11/14 06:53:22
 <br>
-Generated on 2017-11-14 05:32:24+00:00 by file bnf2html.pl version 3.14 dated 2017/11/13 20:42:26
+Generated on 2017-11-14 06:53:25+00:00 by file bnf2html.pl version 3.16 dated 2017/11/14 06:53:22
 </small></i></font></p>
 
 <p>
@@ -915,8 +915,7 @@ Z
 <p><a href='#top'>Top</a></p>
 
 <hr>
-Please send feedback to Jonathan Leffler, variously:
-<a href="mailto:jonathan.leffler@hcl.com"> jonathan.leffler@hcl.com </a> or
+Please send feedback to Jonathan Leffler:
 <a href="mailto:jonathan.leffler@gmail.com"> jonathan.leffler@gmail.com </a>.
 
 </body>

--- a/sql-2003-2.bnf
+++ b/sql-2003-2.bnf
@@ -1,7 +1,7 @@
 BNF Grammar for ISO/IEC 9075-2:2003 - Database Language SQL (SQL-2003) SQL/Foundation
 =====================================================================================
 
-@(#)$Id: sql-2003-2.bnf,v 1.21 2017/10/04 15:15:18 jleffler Exp $
+@(#)$Id: sql-2003-2.bnf,v 1.22 2017/11/14 05:32:12 jleffler Exp $
 
 --p
 Information taken from the Final Committee Draft (FCD) of ISO/IEC 9075-2:2003.
@@ -231,12 +231,16 @@ Specifying lexical units (tokens and separators) that participate in SQL languag
 --p
 --i
 --small
-Previous standard said:
---br
-<identifier start> ::= <initial alphabetic character> | <ideographic character>
+The previous version of the SQL standard defined an identifier start as
+either an <initial alphabetic character> or an <ideographic character>.
+Neither of the defining terms is defined in SQL 2003 (and the SQL 99
+definitions of those defininng terms referred to the syntax rules), but
+the result of the SQL 2003 syntax rules will be similar to SQL 99 ones
+except with Unicode support added.
 --/small
 --/i
 --/p
+--@@     <identifier start> ::= <initial alphabetic character> | <ideographic character>
 
 <identifier start> ::= !! See the Syntax Rules.
 
@@ -263,7 +267,6 @@ The productions for <Unicode delimited identifier> and so on are new in SQL-2003
 <Unicode delimited identifier> ::=
 		U<ampersand><double quote> <Unicode delimiter body> <double quote>
 		<Unicode escape specifier>
-
 
 <Unicode escape specifier> ::= [ UESCAPE <quote> <Unicode escape character> <quote> ]
 
@@ -1514,7 +1517,6 @@ grammar.
 --hr
 --h3 6.11 <case expression> (p197)
 --/h3
-
 
 <case expression> ::= <case abbreviation> | <case specification>
 
@@ -4486,6 +4488,17 @@ Define an SQL-client module.
 
 <module collation specification> ::= COLLATION <collation name> [ FOR <character set specification list> ]
 
+--p
+--i
+--small
+There was another definition <character set specification list> in section 18.3.
+That was slightly different in format (simpler) but functionally equivalent.
+It is not clear why it was repeated.
+The alternative definition is now commented out.
+--/small
+--/i
+--/p
+
 <character set specification list> ::= <character set specification> [ { <comma> <character set specification> }... ]
 
 <module contents> ::=
@@ -5302,7 +5315,14 @@ set.
 		SET COLLATION <collation specification> [ FOR <character set specification list> ]
 	|	SET NO COLLATION [ FOR <character set specification list> ]
 
-<character set specification list> ::= <character set specification> [ , <character set specification>... ]
+--@@ This is a second <character set specification list> definition; the first
+--@@ is in section 13.1.
+--@@ It is marginally different in detail from the previous version, but the
+--@@ overall effect is the same &mdash; a comma-separated list of <character
+--@@ set specification> items.
+--@@ It isn't clear why there's a repeat of the rule or the difference in the expansion.
+--@@
+--@@ <character set specification list> ::= <character set specification> [ , <character set specification>... ]
 
 <collation specification> ::= <value specification>
 
@@ -5350,6 +5370,15 @@ Get information from an SQL descriptor area.
 <header item name> ::= COUNT | KEY_TYPE | DYNAMIC_FUNCTION | DYNAMIC_FUNCTION_CODE | TOP_LEVEL_COUNT
 
 <get item information> ::= <simple target specification 2> <equals operator> <descriptor item name>
+
+--p
+--i
+--small
+The rule for <item number> was repeated verbatim in section 19.5.
+That rule is now omitted.
+--/small
+--/i
+--/p
 
 <item number> ::= <simple value specification>
 
@@ -5417,7 +5446,8 @@ Set information in an SQL descriptor area.
 
 <simple value specification 2> ::= <simple value specification>
 
-<item number> ::= <simple value specification>
+--@@ This <item number> is a repeat of the rule in section 19.4
+--@@ <item number> ::= <simple value specification>
 
 --h3 19.6 <prepare statement> (p941)
 --/h3
@@ -6478,7 +6508,6 @@ returning an implementation-defined subclass in conjunction with one of
 the classes successful completion, warning, or no data.
 --/p
 
-
 --p
 The 'Category' column has the following meanings: 'S' means that the class value given corresponds
 to successful completion and is a completion condition; 'W' means that the class value given
@@ -6652,7 +6681,6 @@ Table 31 - SQLSTATE class and subclass values
 --## <tr><td> X </td><td> with check option violation </td><td> 44 </td><td> (no subclass) </td><td> 000 </td></tr>
 --## </table>
 
-
 --hr
 --h2 24 Conformance
 --/h2
@@ -6710,7 +6738,6 @@ Table 33 - Implied feature relationships
 --## <tr><td> T572 </td><td> Multiset-returning external SQLinvoked functions </td><td> S271 </td><td> Basic multiset support </td></tr>
 --## <tr><td> T612 </td><td> Advanced OLAP operations </td><td> T611 </td><td> Elementary OLAP operations </td></tr>
 --## </table>
-
 
 --hr
 --h2 END OF SQL-2003 Part 2 (SQL/Foundation) GRAMMAR

--- a/sql-2003-2.bnf
+++ b/sql-2003-2.bnf
@@ -1,7 +1,7 @@
 BNF Grammar for ISO/IEC 9075-2:2003 - Database Language SQL (SQL-2003) SQL/Foundation
 =====================================================================================
 
-@(#)$Id: sql-2003-2.bnf,v 1.22 2017/11/14 05:32:12 jleffler Exp $
+@(#)$Id: sql-2003-2.bnf,v 1.23 2017/11/14 06:53:22 jleffler Exp $
 
 --p
 Information taken from the Final Committee Draft (FCD) of ISO/IEC 9075-2:2003.
@@ -252,7 +252,7 @@ except with Unicode support added.
 
 <delimited identifier> ::= <double quote> <delimited identifier body> <double quote>
 
-<delimited identifier body> ::= <delimited identifier part>... 
+<delimited identifier body> ::= <delimited identifier part>...
 
 <delimited identifier part> ::= <nondoublequote character> | <doublequote symbol>
 
@@ -1444,7 +1444,7 @@ grammar.
 <indicator parameter> ::= [ INDICATOR ] <host parameter name>
 
 <target array element specification> ::=
-		<target array reference> <left bracket or trigraph> <simple value specification> <right bracket or trigraph> 
+		<target array reference> <left bracket or trigraph> <simple value specification> <right bracket or trigraph>
 
 <target array reference> ::= <SQL parameter reference> | <column reference>
 
@@ -1663,12 +1663,12 @@ grammar.
 --/h3
 
 <array element reference> ::=
-		<array value expression> <left bracket or trigraph> <numeric value expression> <right bracket or trigraph> 
+		<array value expression> <left bracket or trigraph> <numeric value expression> <right bracket or trigraph>
 
 --hr
 --h3 6.24 <multiset element reference> (p235)
 --/h3
-	
+
 <multiset element reference> ::=
 		ELEMENT <left paren> <multset value expression> <right paren>
 
@@ -1874,7 +1874,7 @@ Specify a function yielding a value of type character string or binary string.
 
 <trim character> ::= <character value expression>
 
-<character overlay function> ::= 
+<character overlay function> ::=
 		OVERLAY <left paren> <character value expression> PLACING <character value expression>
 		FROM <start position> [ FOR <string length> ] [ USING <char length units> ] <right paren>
 
@@ -1956,7 +1956,7 @@ Specify a function yielding a value of type datetime.
 --h3 6.32 <interval value expression> (p271)
 --/h3
 
---p 
+--p
 Specify an interval value.
 --/p
 
@@ -2132,7 +2132,7 @@ Specify a value or list of values to be constructed into a row or partial row.
 --h3 7.2 <row value expression> (p296)
 --/h3
 
---p 
+--p
 Specify a row value.
 --/p
 
@@ -2157,7 +2157,7 @@ Specify a row value.
 --h3 7.3 <table value constructor> (p298)
 --/h3
 
---p 
+--p
 Specify a set of <row value expression>s to be constructed into a table.
 --/p
 
@@ -2172,7 +2172,7 @@ Specify a set of <row value expression>s to be constructed into a table.
 --h3 7.4 <table expression> (p300)
 --/h3
 
---p 
+--p
 Specify a table or a grouped table.
 --/p
 
@@ -2186,7 +2186,7 @@ Specify a table or a grouped table.
 --h3 7.5 <from clause> (p301)
 --/h3
 
---p 
+--p
 Specify a table derived from one or more tables.
 --/p
 
@@ -2197,7 +2197,7 @@ Specify a table derived from one or more tables.
 --h3 7.6 <table reference> (p303)
 --/h3
 
---p 
+--p
 Reference a table.
 --/p
 
@@ -2244,7 +2244,7 @@ Reference a table.
 --h3 7.7 <joined table> (p312)
 --/h3
 
---p 
+--p
 Specify a table derived from a Cartesian product, inner or outer join, or union join.
 --/p
 
@@ -2268,7 +2268,7 @@ Specify a table derived from a Cartesian product, inner or outer join, or union 
 
 <named columns join> ::= USING <left paren> <join column list> <right paren>
 
-<join type> ::= INNER | <outer join type> [ OUTER ] 
+<join type> ::= INNER | <outer join type> [ OUTER ]
 
 <outer join type> ::= LEFT | RIGHT | FULL
 
@@ -2277,7 +2277,7 @@ Specify a table derived from a Cartesian product, inner or outer join, or union 
 --h3 7.8 <where clause> (p319)
 --/h3
 
---p 
+--p
 Specify a table derived by the application of a <search condition> to the result of the preceding
 <from clause>.
 --/p
@@ -2287,7 +2287,7 @@ Specify a table derived by the application of a <search condition> to the result
 --h3 7.9 <group by clause> (p320)
 --/h3
 
---p 
+--p
 Specify a grouped table derived by the application of the <group by clause> to the result of the
 previously specified clause.
 --/p
@@ -2333,7 +2333,7 @@ previously specified clause.
 --h3 7.10 <having clause> (p329)
 --/h3
 
---p 
+--p
 Specify a grouped table derived by the elimination of groups that do not satisfy a <search condition>.
 --/p
 
@@ -2342,7 +2342,7 @@ Specify a grouped table derived by the elimination of groups that do not satisfy
 --h3 7.11 <window clause> (p331)
 --/h3
 
---p 
+--p
 Specify one or more window definitions.
 --/p
 
@@ -2401,7 +2401,7 @@ Specify one or more window definitions.
 --h3 7.12 <query specification> (p341)
 --/h3
 
---p 
+--p
 Specify a table derived from the result of a <table expression>.
 --/p
 
@@ -2430,7 +2430,7 @@ Specify a table derived from the result of a <table expression>.
 --h3 7.13 <query expression> (p350)
 --/h3
 
---p 
+--p
 Specify a table.
 --/p
 
@@ -2477,7 +2477,7 @@ Specify a table.
 --h3 7.14 <search or cycle clause> (p363)
 --/h3
 
---p 
+--p
 Specify the generation of ordering and cycle detection information in the result of recursive query
 expressions.
 --/p
@@ -2516,7 +2516,7 @@ expressions.
 --h3 7.15 <subquery> (p368)
 --/h3
 
---p 
+--p
 Specify a scalar value, a row, or a table derived from a <query expression>.
 --/p
 
@@ -2535,7 +2535,7 @@ Specify a scalar value, a row, or a table derived from a <query expression>.
 --h3 8.1 <predicate> (p371)
 --/h3
 
---p 
+--p
 Specify a condition that can be evaluated to give a boolean value.
 --/p
 
@@ -2561,7 +2561,7 @@ Specify a condition that can be evaluated to give a boolean value.
 --h3 8.2 <comparison predicate> (p373)
 --/h3
 
---p 
+--p
 Specify a comparison of two row values.
 --/p
 
@@ -2580,7 +2580,7 @@ Specify a comparison of two row values.
 --h3 8.3 <between predicate> (p380)
 --/h3
 
---p 
+--p
 Specify a range comparison.
 --/p
 
@@ -2591,11 +2591,11 @@ Specify a range comparison.
 --h3 8.4 <in predicate> (p381)
 --/h3
 
---p 
+--p
 Specify a quantified comparison.
 --/p
 
-<in predicate> ::= <row value predicand> <in predicate part 2> 
+<in predicate> ::= <row value predicand> <in predicate part 2>
 
 <in predicate part 2> ::= [ NOT ] IN <in predicate value>
 
@@ -2608,7 +2608,7 @@ Specify a quantified comparison.
 --h3 8.5 <like predicate> (p383)
 --/h3
 
---p 
+--p
 Specify a pattern-match comparison.
 --/p
 
@@ -2633,7 +2633,7 @@ Specify a pattern-match comparison.
 --h3 8.6 <similar predicate> (p389)
 --/h3
 
---p 
+--p
 Specify a character string similarity by means of a regular expression.
 --/p
 
@@ -2698,18 +2698,18 @@ Specify a character string similarity by means of a regular expression.
 --h3 8.7 <null predicate> (p395)
 --/h3
 
---p 
+--p
 Specify a test for a null value.
 --/p
 
 <null predicate> ::= <row value predicand> <null predicate part 2>
 
-<null predicate part 2> ::= IS [ NOT ] NULL 
+<null predicate part 2> ::= IS [ NOT ] NULL
 
 --h3 8.8 <quantified comparison predicate> (p397)
 --/h3
 
---p 
+--p
 Specify a quantified comparison.
 --/p
 
@@ -2726,7 +2726,7 @@ Specify a quantified comparison.
 --h3 8.9 <exists predicate> (p399)
 --/h3
 
---p 
+--p
 Specify a test for a non-empty set.
 --/p
 
@@ -2744,7 +2744,7 @@ Specify a test for the absence of duplicate rows
 --h3 8.11 <normalized predicate> (p401)
 --/h3
 
---p 
+--p
 Determine whether a character string value is normalized.
 --/p
 
@@ -2753,7 +2753,7 @@ Determine whether a character string value is normalized.
 --h3 8.12 <match predicate> (p402)
 --/h3
 
---p 
+--p
 Specify a test for matching rows.
 --/p
 
@@ -2764,7 +2764,7 @@ Specify a test for matching rows.
 --h3 8.13 <overlaps predicate> (p405)
 --/h3
 
---p 
+--p
 Specify a test for an overlap between two datetime periods.
 --/p
 
@@ -2781,7 +2781,7 @@ Specify a test for an overlap between two datetime periods.
 --h3 8.14 <distinct predicate> (p407)
 --/h3
 
---p 
+--p
 Specify a test of whether two row values are distinct
 --/p
 
@@ -2796,7 +2796,7 @@ Specify a test of whether two row values are distinct
 --h3 8.15 <member predicate> (p409)
 --/h3
 
---p 
+--p
 Specify a test of whether a value is a member of a multiset.
 --/p
 
@@ -2807,7 +2807,7 @@ Specify a test of whether a value is a member of a multiset.
 --h3 8.16 <submultiset predicate> (p411)
 --/h3
 
---p 
+--p
 Specify a test of whether a multiset is a submultiset of another multiset.
 --/p
 
@@ -2818,7 +2818,7 @@ Specify a test of whether a multiset is a submultiset of another multiset.
 --h3 8.17 <set predicate> (p413)
 --/h3
 
---p 
+--p
 Specify a test of whether a multiset is a set (that is, does not contain any duplicates).
 --/p
 
@@ -2829,7 +2829,7 @@ Specify a test of whether a multiset is a set (that is, does not contain any dup
 --h3 8.18 <type predicate> (p414)
 --/h3
 
---p 
+--p
 Specify a type test.
 --/p
 
@@ -2850,7 +2850,7 @@ Specify a type test.
 --h3 8.19 <search condition> (p416)
 --/h3
 
---p 
+--p
 Specify a condition that is True , False , or Unknown , depending on the value of a <boolean value
 expression>.
 --/p
@@ -2937,7 +2937,7 @@ expression>.
 --h3 10.1 <interval qualifier> (p465)
 --/h3
 
---p 
+--p
 Specify the precision of an interval data type.
 --/p
 
@@ -2968,7 +2968,7 @@ Specify the precision of an interval data type.
 --h3 10.2 <language clause> (p469)
 --/h3
 
---p 
+--p
 Specify a standard programming language.
 --/p
 
@@ -2995,7 +2995,7 @@ Table 14 -- Standard programming languages
 --h3 10.3 <path specification> (p471)
 --/h3
 
---p 
+--p
 Specify an order for searching for an SQL-invoked routine.
 --/p
 
@@ -3006,7 +3006,7 @@ Specify an order for searching for an SQL-invoked routine.
 --h3 10.4 <routine invocation> (p472)
 --/h3
 
---p 
+--p
 Invoke an SQL-invoked routine.
 --/p
 
@@ -3026,7 +3026,7 @@ Invoke an SQL-invoked routine.
 --h3 10.5 <character set specification> (p495)
 --/h3
 
---p 
+--p
 Identify a character set.
 --/p
 
@@ -3044,7 +3044,7 @@ Identify a character set.
 --h3 10.6 <specific routine designator> (p497)
 --/h3
 
---p 
+--p
 Specify an SQL-invoked routine.
 --/p
 
@@ -3068,7 +3068,7 @@ Specify an SQL-invoked routine.
 --h3 10.7 <collate clause> (p500)
 --/h3
 
---p 
+--p
 Specify a default collating sequence.
 --/p
 
@@ -3077,7 +3077,7 @@ Specify a default collating sequence.
 --h3 10.8 <constraint name definition> and <constraint characteristics> (p501)
 --/h3
 
---p 
+--p
 Specify the name of a constraint and its characteristics.
 --/p
 
@@ -3092,7 +3092,7 @@ Specify the name of a constraint and its characteristics.
 --h3 10.9 <aggregate function> (p503)
 --/h3
 
---p 
+--p
 Specify a value computed from a collection of rows.
 --/p
 
@@ -3145,7 +3145,7 @@ Specify a value computed from a collection of rows.
 --h3 10.10 <sort specification list> (p515)
 --/h3
 
---p 
+--p
 Specify a sort order.
 --/p
 
@@ -3166,7 +3166,7 @@ Specify a sort order.
 --h3 11.1 <schema definition> (p517)
 --/h3
 
---p 
+--p
 Define a schema.
 --/p
 
@@ -3210,7 +3210,7 @@ Define a schema.
 --h3 11.2 <drop schema statement> (p520)
 --/h3
 
---p 
+--p
 Destroy a schema.
 --/p
 
@@ -3221,7 +3221,7 @@ Destroy a schema.
 --h3 11.3 <table definition> (p523)
 --/h3
 
---p 
+--p
 Define a persistent base table, a created local temporary table, or a global temporary table.
 --/p
 
@@ -3280,7 +3280,7 @@ Define a persistent base table, a created local temporary table, or a global tem
 --h3 11.4 <column definition> (p534)
 --/h3
 
---p 
+--p
 Define a column of a base table.
 --/p
 
@@ -3314,7 +3314,7 @@ Define a column of a base table.
 --h3 11.5 <default clause> (p539)
 --/h3
 
---p 
+--p
 Specify the default for a column, domain, or attribute.
 --/p
 
@@ -3334,7 +3334,7 @@ Specify the default for a column, domain, or attribute.
 --h3 11.6 <table constraint definition> (p543)
 --/h3
 
---p 
+--p
 Specify an integrity constraint.
 --/p
 
@@ -3348,7 +3348,7 @@ Specify an integrity constraint.
 --h3 11.7 <unique constraint definition> (p545)
 --/h3
 
---p 
+--p
 Specify a uniqueness constraint for a table.
 --/p
 
@@ -3363,7 +3363,7 @@ Specify a uniqueness constraint for a table.
 --h3 11.8 <referential constraint definition> (p547)
 --/h3
 
---p 
+--p
 Specify a referential constraint.
 --/p
 
@@ -3390,7 +3390,7 @@ Specify a referential constraint.
 --h3 11.9 <check constraint definition> (p567)
 --/h3
 
---p 
+--p
 Specify a condition for the SQL-data.
 --/p
 
@@ -3399,7 +3399,7 @@ Specify a condition for the SQL-data.
 --h3 11.10 <alter table statement> (p569)
 --/h3
 
---p 
+--p
 Change the definition of a table.
 --/p
 
@@ -3415,7 +3415,7 @@ Change the definition of a table.
 --h3 11.11 <add column definition> (p570)
 --/h3
 
---p 
+--p
 Add a column to a table.
 --/p
 
@@ -3424,7 +3424,7 @@ Add a column to a table.
 --h3 11.12 <alter column definition> (p572)
 --/h3
 
---p 
+--p
 Change a column and its definition.
 --/p
 
@@ -3440,7 +3440,7 @@ Change a column and its definition.
 --h3 11.13 <set column default clause> (p573)
 --/h3
 
---p 
+--p
 Set the default clause for a column.
 --/p
 
@@ -3449,7 +3449,7 @@ Set the default clause for a column.
 --h3 11.14 <drop column default clause> (p574)
 --/h3
 
---p 
+--p
 Drop the default clause from a column.
 --/p
 
@@ -3458,7 +3458,7 @@ Drop the default clause from a column.
 --h3 11.15 <add column scope clause> (p575)
 --/h3
 
---p 
+--p
 Add a non-empty scope for an existing column of data type REF in a base table.
 --/p
 
@@ -3467,7 +3467,7 @@ Add a non-empty scope for an existing column of data type REF in a base table.
 --h3 11.16 <drop column scope clause> (p576)
 --/h3
 
---p 
+--p
 Drop the scope from an existing column of data type REF in a base table.
 --/p
 
@@ -3476,7 +3476,7 @@ Drop the scope from an existing column of data type REF in a base table.
 --h3 11.17 <alter identity column specification> (p578)
 --/h3
 
---p 
+--p
 Change the options specified for an identity column.
 --/p
 
@@ -3489,7 +3489,7 @@ Change the options specified for an identity column.
 --h3 11.18 <drop column definition> (p579)
 --/h3
 
---p 
+--p
 Destroy a column of a base table.
 --/p
 
@@ -3498,7 +3498,7 @@ Destroy a column of a base table.
 --h3 11.19 <add table constraint definition> (p581)
 --/h3
 
---p 
+--p
 Add a constraint to a table.
 --/p
 
@@ -3507,7 +3507,7 @@ Add a constraint to a table.
 --h3 11.20 <drop table constraint definition> (p582)
 --/h3
 
---p 
+--p
 Destroy a constraint on a table.
 --/p
 
@@ -3516,7 +3516,7 @@ Destroy a constraint on a table.
 --h3 11.21 <drop table statement> (p585)
 --/h3
 
---p 
+--p
 Destroy a table.
 --/p
 
@@ -3525,7 +3525,7 @@ Destroy a table.
 --h3 11.22 <view definition> (p588)
 --/h3
 
---p 
+--p
 Define a viewed table.
 --/p
 
@@ -3554,7 +3554,7 @@ Define a viewed table.
 --h3 11.23 <drop view statement> (p598)
 --/h3
 
---p 
+--p
 Destroy a view.
 --/p
 
@@ -3563,7 +3563,7 @@ Destroy a view.
 --h3 11.24 <domain definition> (p601)
 --/h3
 
---p 
+--p
 Define a domain.
 --/p
 
@@ -3576,7 +3576,7 @@ Define a domain.
 --h3 11.25 <alter domain statement> (p603)
 --/h3
 
---p 
+--p
 Change a domain and its definition.
 --/p
 
@@ -3591,7 +3591,7 @@ Change a domain and its definition.
 --h3 11.26 <set domain default clause> (p604)
 --/h3
 
---p 
+--p
 Set the default value in a domain.
 --/p
 
@@ -3600,7 +3600,7 @@ Set the default value in a domain.
 --h3 11.27 <drop domain default clause> (p605)
 --/h3
 
---p 
+--p
 Remove the default clause of a domain.
 --/p
 
@@ -3609,7 +3609,7 @@ Remove the default clause of a domain.
 --h3 11.28 <add domain constraint definition> (p606)
 --/h3
 
---p 
+--p
 Add a constraint to a domain.
 --/p
 
@@ -3618,7 +3618,7 @@ Add a constraint to a domain.
 --h3 11.29 <drop domain constraint definition> (p607)
 --/h3
 
---p 
+--p
 Destroy a constraint on a domain.
 --/p
 
@@ -3627,7 +3627,7 @@ Destroy a constraint on a domain.
 --h3 11.30 <drop domain statement> (p608)
 --/h3
 
---p 
+--p
 Destroy a domain.
 --/p
 
@@ -3636,7 +3636,7 @@ Destroy a domain.
 --h3 11.31 <character set definition> (p610)
 --/h3
 
---p 
+--p
 Define a character set.
 --/p
 
@@ -3648,7 +3648,7 @@ Define a character set.
 --h3 11.32 <drop character set statement> (p612)
 --/h3
 
---p 
+--p
 Destroy a character set.
 --/p
 
@@ -3657,7 +3657,7 @@ Destroy a character set.
 --h3 11.33 <collation definition> (p614)
 --/h3
 
---p 
+--p
 Define a collating sequence.
 --/p
 
@@ -3672,7 +3672,7 @@ Define a collating sequence.
 --h3 11.34 <drop collation statement> (p616)
 --/h3
 
---p 
+--p
 Destroy a collating sequence.
 --/p
 
@@ -3681,7 +3681,7 @@ Destroy a collating sequence.
 --h3 11.35 <transliteration definition> (p618)
 --/h3
 
---p 
+--p
 Define a character transliteration.
 --/p
 
@@ -3702,7 +3702,7 @@ Define a character transliteration.
 --h3 11.36 <drop transliteration statement> (p621)
 --/h3
 
---p 
+--p
 Destroy a character transliteration.
 --/p
 
@@ -3711,7 +3711,7 @@ Destroy a character transliteration.
 --h3 11.37 <assertion definition> (p623)
 --/h3
 
---p 
+--p
 Specify an integrity constraint.
 --/p
 
@@ -3721,7 +3721,7 @@ Specify an integrity constraint.
 --h3 11.38 <drop assertion statement> (p625)
 --/h3
 
---p 
+--p
 Destroy an assertion.
 --/p
 
@@ -3730,7 +3730,7 @@ Destroy an assertion.
 --h3 11.39 <trigger definition> (p627)
 --/h3
 
---p 
+--p
 Define triggered SQL-statements.
 --/p
 
@@ -3773,7 +3773,7 @@ Define triggered SQL-statements.
 --h3 11.40 <drop trigger statement> (p631)
 --/h3
 
---p 
+--p
 Destroy a trigger.
 --/p
 
@@ -3782,7 +3782,7 @@ Destroy a trigger.
 --h3 11.41 <user-defined type definition> (p632)
 --/h3
 
---p 
+--p
 Define a user-defined type.
 --/p
 
@@ -3881,7 +3881,7 @@ Define a user-defined type.
 --h3 11.42 <attribute definition> (p648)
 --/h3
 
---p 
+--p
 Define an attribute of a structured type.
 --/p
 
@@ -3893,7 +3893,7 @@ Define an attribute of a structured type.
 --h3 11.43 <alter type statement> (p650)
 --/h3
 
---p 
+--p
 Change the definition of a user-defined type.
 --/p
 
@@ -3910,7 +3910,7 @@ ALTER TYPE <schema-resolved user-defined type name> <alter type action>
 --h3 11.44 <add attribute definition> (p651)
 --/h3
 
---p 
+--p
 Add an attribute to a user-defined type.
 --/p
 
@@ -3919,7 +3919,7 @@ Add an attribute to a user-defined type.
 --h3 11.45 <drop attribute definition> (p653)
 --/h3
 
---p 
+--p
 Destroy an attribute of a user-defined type.
 --/p
 
@@ -3928,7 +3928,7 @@ Destroy an attribute of a user-defined type.
 --h3 11.46 <add original method specification> (p655)
 --/h3
 
---p 
+--p
 Add an original method specification to a user-defined type.
 --/p
 
@@ -3937,7 +3937,7 @@ Add an original method specification to a user-defined type.
 --h3 11.47 <add overriding method specification> (p661)
 --/h3
 
---p 
+--p
 Add an overriding method specification to a user-defined type.
 --/p
 
@@ -3946,7 +3946,7 @@ Add an overriding method specification to a user-defined type.
 --h3 11.48 <drop method specification> (p666)
 --/h3
 
---p 
+--p
 Remove a method specification from a user-defined type.
 --/p
 
@@ -3957,7 +3957,7 @@ Remove a method specification from a user-defined type.
 --h3 11.49 <drop data type statement> (p670)
 --/h3
 
---p 
+--p
 Destroy a user-defined type.
 --/p
 
@@ -3966,7 +3966,7 @@ Destroy a user-defined type.
 --h3 11.50 <SQL-invoked routine> (p673)
 --/h3
 
---p 
+--p
 Define an SQL-invoked routine.
 --/p
 
@@ -4091,7 +4091,7 @@ Define an SQL-invoked routine.
 --h3 11.51 <alter routine statement> (p698)
 --/h3
 
---p 
+--p
 Alter a characteristic of an SQL-invoked routine.
 --/p
 
@@ -4112,7 +4112,7 @@ Alter a characteristic of an SQL-invoked routine.
 --h3 11.52 <drop routine statement> (p701)
 --/h3
 
---p 
+--p
 Destroy an SQL-invoked routine.
 --/p
 
@@ -4121,7 +4121,7 @@ Destroy an SQL-invoked routine.
 --h3 11.53 <user-defined cast definition> (p703)
 --/h3
 
---p 
+--p
 Define a user-defined cast.
 --/p
 
@@ -4138,7 +4138,7 @@ Define a user-defined cast.
 --h3 11.54 <drop user-defined cast statement> (p705)
 --/h3
 
---p 
+--p
 Destroy a user-defined cast.
 --/p
 
@@ -4148,7 +4148,7 @@ Destroy a user-defined cast.
 --h3 11.55 <user-defined ordering definition> (p707)
 --/h3
 
---p 
+--p
 Define a user-defined ordering for a user-defined type.
 --/p
 
@@ -4176,7 +4176,7 @@ Define a user-defined ordering for a user-defined type.
 --h3 11.56 <drop user-defined ordering statement> (p710)
 --/h3
 
---p 
+--p
 Destroy a user-defined ordering method.
 --/p
 
@@ -4186,7 +4186,7 @@ Destroy a user-defined ordering method.
 --h3 11.57 <transform definition> (p712)
 --/h3
 
---p 
+--p
 Define one or more transform functions for a user-defined type.
 --/p
 
@@ -4211,7 +4211,7 @@ Define one or more transform functions for a user-defined type.
 --h3 11.58 <alter transform statement> (p715)
 --/h3
 
---p 
+--p
 Change the definition of one or more transform groups.
 --/p
 
@@ -4227,7 +4227,7 @@ Change the definition of one or more transform groups.
 --h3 11.59 <add transform element list> (p717)
 --/h3
 
---p 
+--p
 Add a transform element (<to sql> and/or <from sql>) to an existing transform group.
 --/p
 
@@ -4236,7 +4236,7 @@ Add a transform element (<to sql> and/or <from sql>) to an existing transform gr
 --h3 11.60 <drop transform element list> (p719)
 --/h3
 
---p 
+--p
 Remove a transform element (<to sql> and/or <from sql>) from a transform group.
 --/p
 
@@ -4247,7 +4247,7 @@ Remove a transform element (<to sql> and/or <from sql>) from a transform group.
 --h3 11.61 <drop transform statement> (p721)
 --/h3
 
---p 
+--p
 Remove one or more transform functions associated with a transform.
 --/p
 
@@ -4261,7 +4261,7 @@ Remove one or more transform functions associated with a transform.
 --h3 11.62 <sequence generator definition> (p724)
 --/h3
 
---p 
+--p
 Define an external sequence generator.
 --/p
 
@@ -4306,7 +4306,7 @@ Define an external sequence generator.
 --h3 11.63 <alter sequence generator statement> (p726)
 --/h3
 
---p 
+--p
 Change the definition of an external sequence generator.
 --/p
 
@@ -4326,7 +4326,7 @@ Change the definition of an external sequence generator.
 --h3 11.64 <drop sequence generator statement> (p727)
 --/h3
 
---p 
+--p
 Destroy an external sequence generator.
 --/p
 
@@ -4339,7 +4339,7 @@ Destroy an external sequence generator.
 --h3 12.1 <grant statement> (p729)
 --/h3
 
---p 
+--p
 Define privileges and role authorizations.
 --/p
 
@@ -4348,7 +4348,7 @@ Define privileges and role authorizations.
 --h3 12.2 <grant privilege statement> (p734)
 --/h3
 
---p 
+--p
 Define privileges.
 --/p
 
@@ -4359,7 +4359,7 @@ Define privileges.
 --h3 12.3 <privileges> (p737)
 --/h3
 
---p 
+--p
 Specify privileges.
 --/p
 
@@ -4403,7 +4403,7 @@ Specify privileges.
 --h3 12.4 <role definition> (p741)
 --/h3
 
---p 
+--p
 Define a role.
 --/p
 
@@ -4412,7 +4412,7 @@ Define a role.
 --h3 12.5 <grant role statement> (p742)
 --/h3
 
---p 
+--p
 Define role authorizations.
 --/p
 
@@ -4425,7 +4425,7 @@ Define role authorizations.
 --h3 12.6 <drop role statement> (p744)
 --/h3
 
---p 
+--p
 Destroy a role.
 --/p
 
@@ -4434,7 +4434,7 @@ Destroy a role.
 --h3 12.7 <revoke statement> (p745)
 --/h3
 
---p 
+--p
 Destroy privileges and role authorizations.
 --/p
 
@@ -4461,7 +4461,7 @@ Destroy privileges and role authorizations.
 --h3 13.1 <SQL-client module definition> (p763)
 --/h3
 
---p 
+--p
 Define an SQL-client module.
 --/p
 
@@ -4509,7 +4509,7 @@ The alternative definition is now commented out.
 --h3 13.2 <module name clause> (p768)
 --/h3
 
---p 
+--p
 Name an SQL-client module.
 --/p
 
@@ -4521,7 +4521,7 @@ Name an SQL-client module.
 --h3 13.3 <externally-invoked procedure> (p769)
 --/h3
 
---p 
+--p
 Define an externally-invoked procedure.
 --/p
 
@@ -4546,7 +4546,7 @@ Define an externally-invoked procedure.
 --h3 13.5 <SQL procedure statement> (p788)
 --/h3
 
---p 
+--p
 Define all of the SQL-statements that are <SQL procedure statement>s.
 --/p
 
@@ -4759,7 +4759,7 @@ unsigned char should be used.
 --h3 14.1 <declare cursor> (p807)
 --/h3
 
---p 
+--p
 Define a cursor.
 --/p
 
@@ -4775,7 +4775,7 @@ Define a cursor.
 
 <cursor returnability> ::= WITH RETURN | WITHOUT RETURN
 
-<cursor specification> ::= <query expression> [ <order by clause> ] [ <updatability clause> ] 
+<cursor specification> ::= <query expression> [ <order by clause> ] [ <updatability clause> ]
 
 <updatability clause> ::= FOR { READ ONLY | UPDATE [ OF <column name list> ] }
 
@@ -4784,7 +4784,7 @@ Define a cursor.
 --h3 14.2 <open statement> (p813)
 --/h3
 
---p 
+--p
 Open a cursor.
 --/p
 
@@ -4793,7 +4793,7 @@ Open a cursor.
 --h3 14.3 <fetch statement> (p815)
 --/h3
 
---p 
+--p
 Position a cursor on a specified row of a table and retrieve values from that row.
 --/p
 
@@ -4821,7 +4821,7 @@ Close a cursor.
 --h3 14.5 <select statement: single row> (p822)
 --/h3
 
---p 
+--p
 Retrieve values from a specified row of a table.
 --/p
 
@@ -4833,7 +4833,7 @@ Retrieve values from a specified row of a table.
 --h3 14.6 <delete statement: positioned> (p826)
 --/h3
 
---p 
+--p
 Delete a row of a table.
 --/p
 
@@ -4846,7 +4846,7 @@ Delete a row of a table.
 --h3 14.7 <delete statement: searched> (p829)
 --/h3
 
---p 
+--p
 Delete rows of a table.
 --/p
 
@@ -4855,7 +4855,7 @@ Delete rows of a table.
 --h3 14.8 <insert statement> (p832)
 --/h3
 
---p 
+--p
 Create new rows in a table.
 --/p
 
@@ -4882,7 +4882,7 @@ Create new rows in a table.
 --h3 14.9 <merge statement> (p837)
 --/h3
 
---p 
+--p
 Conditionally update rows of a table, or insert new rows into a table, or both.
 --/p
 
@@ -4914,7 +4914,7 @@ Conditionally update rows of a table, or insert new rows into a table, or both.
 --h3 14.10 <update statement: positioned> (p844)
 --/h3
 
---p 
+--p
 Update a row of a table.
 --/p
 
@@ -4923,7 +4923,7 @@ Update a row of a table.
 --h3 14.11 <update statement: searched> (p847)
 --/h3
 
---p 
+--p
 Update rows of a table.
 --/p
 
@@ -4932,7 +4932,7 @@ Update rows of a table.
 --h3 14.12 <set clause list> (p851)
 --/h3
 
---p 
+--p
 Specify a list of updates.
 --/p
 
@@ -4965,7 +4965,7 @@ Specify a list of updates.
 --h3 14.13 <temporary table declaration> (p856)
 --/h3
 
---p 
+--p
 Declare a declared local temporary table.
 --/p
 
@@ -4976,7 +4976,7 @@ Declare a declared local temporary table.
 --h3 14.14 <free locator statement> (p858)
 --/h3
 
---p 
+--p
 Remove the association between a locator variable and the value that is represented by that locator.
 --/p
 
@@ -4987,7 +4987,7 @@ Remove the association between a locator variable and the value that is represen
 --h3 14.15 <hold locator statement> (p859)
 --/h3
 
---p 
+--p
 Mark a locator variable as being holdable.
 --/p
 
@@ -5036,7 +5036,7 @@ Mark a locator variable as being holdable.
 --h3 15.1 <call statement> (p883)
 --/h3
 
---p 
+--p
 Invoke an SQL-invoked routine.
 --/p
 
@@ -5045,7 +5045,7 @@ Invoke an SQL-invoked routine.
 --h3 15.2 <return statement> (p884)
 --/h3
 
---p 
+--p
 Return a value from an SQL function.
 --/p
 
@@ -5060,7 +5060,7 @@ Return a value from an SQL function.
 --h3 16.1 <start transaction statement> (p885)
 --/h3
 
---p 
+--p
 Start an SQL-transaction and set its characteristics.
 --/p
 
@@ -5081,7 +5081,7 @@ Start an SQL-transaction and set its characteristics.
 --h3 16.2 <set transaction statement> (p888)
 --/h3
 
---p 
+--p
 Set the characteristics of the next SQL-transaction for the SQL-agent.
 NOTE 402 - This statement has no effect on any SQL-transactions subsequent to the next SQL-transaction.
 --/p
@@ -5093,7 +5093,7 @@ NOTE 402 - This statement has no effect on any SQL-transactions subsequent to th
 --h3 16.3 <set constraints mode statement> (p890)
 --/h3
 
---p 
+--p
 If an SQL-transaction is currently active, then set the constraint mode for that SQL-transaction in
 the current SQL-session. If no SQL-transaction is currently active, then set the constraint mode for
 the next SQL-transaction in the current SQL-session for the SQL-agent.
@@ -5107,7 +5107,7 @@ NOTE 404: This statement has no effect on any SQL-transactions subsequent to thi
 --h3 16.4 <savepoint statement> (p892)
 --/h3
 
---p 
+--p
 Establish a savepoint.
 --/p
 
@@ -5118,7 +5118,7 @@ Establish a savepoint.
 --h3 16.5 <release savepoint statement> (p893)
 --/h3
 
---p 
+--p
 Destroy a savepoint.
 --/p
 
@@ -5127,7 +5127,7 @@ Destroy a savepoint.
 --h3 16.6 <commit statement> (p894)
 --/h3
 
---p 
+--p
 Terminate the current SQL-transaction with commit.
 --/p
 
@@ -5136,7 +5136,7 @@ Terminate the current SQL-transaction with commit.
 --h3 16.7 <rollback statement> (p896)
 --/h3
 
---p 
+--p
 Terminate the current SQL-transaction with rollback, or rollback all actions affecting SQL-data
 and/or schemas since the establishment of a savepoint.
 --/p
@@ -5152,7 +5152,7 @@ and/or schemas since the establishment of a savepoint.
 --h3 17.1 <connect statement> (p899)
 --/h3
 
---p 
+--p
 Establish an SQL-session.
 --/p
 
@@ -5165,18 +5165,18 @@ Establish an SQL-session.
 --h3 17.2 <set connection statement> (p902)
 --/h3
 
---p 
+--p
 Select an SQL-connection from the available SQL-connections.
 --/p
 
 <set connection statement> ::= SET CONNECTION <connection object>
 
-<connection object> ::= DEFAULT | <connection name> 
+<connection object> ::= DEFAULT | <connection name>
 
 --h3 17.3 <disconnect statement> (p904)
 --/h3
 
---p 
+--p
 Terminate an SQL-connection.
 --/p
 
@@ -5191,7 +5191,7 @@ Terminate an SQL-connection.
 --h3 18.1 <set session characteristics statement> (p907)
 --/h3
 
---p 
+--p
 Set one or more characteristics for the current SQL-session.
 --/p
 
@@ -5204,7 +5204,7 @@ Set one or more characteristics for the current SQL-session.
 --h3 18.2 <set session user identifier statement> (p908)
 --/h3
 
---p 
+--p
 Set the SQL-session user identifier and the current user identifier of the current SQL-session
 context.
 --/p
@@ -5214,7 +5214,7 @@ context.
 --h3 18.3 <set role statement> (p909)
 --/h3
 
---p 
+--p
 Set the current role name for the current SQL-session context.
 --/p
 
@@ -5225,7 +5225,7 @@ Set the current role name for the current SQL-session context.
 --h3 18.4 <set local time zone statement> (p911)
 --/h3
 
---p 
+--p
 Set the default local time zone displacement for the current SQL-session.
 --/p
 
@@ -5236,7 +5236,7 @@ Set the default local time zone displacement for the current SQL-session.
 --h3 18.5 <set catalog statement> (p912)
 --/h3
 
---p 
+--p
 Set the default catalog name for unqualified <schema name>s in <preparable statement>s that
 are prepared in the current SQL-session by an <execute immediate statement> or a <prepare
 statement> and in <direct SQL statement>s that are invoked directly.
@@ -5249,7 +5249,7 @@ statement> and in <direct SQL statement>s that are invoked directly.
 --h3 18.6 <set schema statement> (p913)
 --/h3
 
---p 
+--p
 Set the default schema name for unqualified <schema qualified name>s in <preparable statement>s
 that are prepared in the current SQL-session by an <execute immediate statement> or a <prepare
 statement> and in <direct SQL statement>s that are invoked directly.
@@ -5262,7 +5262,7 @@ statement> and in <direct SQL statement>s that are invoked directly.
 --h3 18.7 <set names statement> (p915)
 --/h3
 
---p 
+--p
 Set the default character set name for <character string literal>s in <preparable statement>s that
 are prepared in the current SQL-session by an <execute immediate statement> or a <prepare
 statement> and in <direct SQL statement>s that are invoked directly.
@@ -5275,7 +5275,7 @@ statement> and in <direct SQL statement>s that are invoked directly.
 --h3 18.8 <set path statement> (p916)
 --/h3
 
---p 
+--p
 Set the SQL-path used to determine the subject routine of <routine invocation>s with unqualified
 <routine name>s in <preparable statement>s that are prepared in the current SQL-session by
 an <execute immediate statement> or a <prepare statement> and in <direct SQL statement>s,
@@ -5290,7 +5290,7 @@ until another SQL-path is successfully set.
 --h3 18.9 <set transform group statement> (p917)
 --/h3
 
---p 
+--p
 Set the group name that identifies the group of transform functions for
 mapping values of userdefined types to predefined data types.
 --/p
@@ -5304,7 +5304,7 @@ mapping values of userdefined types to predefined data types.
 --h3 18.10 <set session collation statement> (p918)
 --/h3
 
---p 
+--p
 Set the SQL-session collation of the SQL-session for one or more
 character sets.  An SQL-session collation remains effective until
 another SQL-session collation for the same character set is successfully
@@ -5335,7 +5335,7 @@ set.
 --h3 19.2 <allocate descriptor statement> (p931)
 --/h3
 
---p 
+--p
 Allocate an SQL descriptor area.
 --/p
 
@@ -5346,7 +5346,7 @@ Allocate an SQL descriptor area.
 --h3 19.3 <deallocate descriptor statement> (p933)
 --/h3
 
---p 
+--p
 Deallocate an SQL descriptor area.
 --/p
 
@@ -5355,7 +5355,7 @@ Deallocate an SQL descriptor area.
 --h3 19.4 <get descriptor statement> (p934)
 --/h3
 
---p 
+--p
 Get information from an SQL descriptor area.
 --/p
 
@@ -5428,7 +5428,7 @@ That rule is now omitted.
 --h3 19.5 <set descriptor statement> (p937)
 --/h3
 
---p 
+--p
 Set information in an SQL descriptor area.
 --/p
 
@@ -5452,7 +5452,7 @@ Set information in an SQL descriptor area.
 --h3 19.6 <prepare statement> (p941)
 --/h3
 
---p 
+--p
 Prepare a statement for execution.
 --/p
 
@@ -5498,7 +5498,7 @@ Prepare a statement for execution.
 --h3 19.7 <cursor attributes> (p953)
 --/h3
 
---p 
+--p
 Specify a list of cursor attributes.
 --/p
 
@@ -5513,7 +5513,7 @@ Specify a list of cursor attributes.
 --h3 19.8 <deallocate prepared statement> (p954)
 --/h3
 
---p 
+--p
 Deallocate SQL-statements that have been prepared with a <prepare statement>.
 --/p
 
@@ -5522,7 +5522,7 @@ Deallocate SQL-statements that have been prepared with a <prepare statement>.
 --h3 19.9 <describe statement> (p955)
 --/h3
 
---p 
+--p
 Obtain information about the <select list> columns or <dynamic parameter specification>s contained
 in a prepared statement or about the columns of the result set associated with a cursor.
 --/p
@@ -5544,7 +5544,7 @@ in a prepared statement or about the columns of the result set associated with a
 --h3 19.10 <input using clause> (p961)
 --/h3
 
---p 
+--p
 Supply input values for an <SQL dynamic statement>.
 --/p
 
@@ -5559,7 +5559,7 @@ Supply input values for an <SQL dynamic statement>.
 --h3 19.11 <output using clause> (p965)
 --/h3
 
---p 
+--p
 Supply output variables for an <SQL dynamic statement>.
 --/p
 
@@ -5574,7 +5574,7 @@ Supply output variables for an <SQL dynamic statement>.
 --h3 19.12 <execute statement> (p970)
 --/h3
 
---p 
+--p
 Associate input SQL parameters and output targets with a prepared statement and execute the
 statement.
 --/p
@@ -5588,7 +5588,7 @@ statement.
 --h3 19.13 <execute immediate statement> (p972)
 --/h3
 
---p 
+--p
 Dynamically prepare and execute a preparable statement.
 --/p
 
@@ -5597,7 +5597,7 @@ Dynamically prepare and execute a preparable statement.
 --h3 19.14 <dynamic declare cursor> (p973)
 --/h3
 
---p 
+--p
 Declare a cursor to be associated with a <statement name>, which may in turn be associated with a
 <cursor specification>.
 --/p
@@ -5609,7 +5609,7 @@ Declare a cursor to be associated with a <statement name>, which may in turn be 
 --h3 19.15 <allocate cursor statement> (p974)
 --/h3
 
---p 
+--p
 Define a cursor based on a prepared statement for a <cursor specification> or assign a cursor to the
 ordered set of result sets returned from an SQL-invoked procedure.
 --/p
@@ -5627,7 +5627,7 @@ ordered set of result sets returned from an SQL-invoked procedure.
 --h3 19.16 <dynamic open statement> (p976)
 --/h3
 
---p 
+--p
 Associate input dynamic parameters with a <cursor specification> and open the cursor.
 --/p
 
@@ -5636,7 +5636,7 @@ Associate input dynamic parameters with a <cursor specification> and open the cu
 --h3 19.17 <dynamic fetch statement> (p977)
 --/h3
 
---p 
+--p
 Fetch a row for a cursor declared with a <dynamic declare cursor>.
 --/p
 
@@ -5645,7 +5645,7 @@ Fetch a row for a cursor declared with a <dynamic declare cursor>.
 --h3 19.18 <dynamic single row select statement> (p978)
 --/h3
 
---p 
+--p
 Retrieve values from a dynamically-specified row of a table.
 --/p
 
@@ -5654,7 +5654,7 @@ Retrieve values from a dynamically-specified row of a table.
 --h3 19.19 <dynamic close statement> (p979)
 --/h3
 
---p 
+--p
 Close a cursor.
 --/p
 
@@ -5663,7 +5663,7 @@ Close a cursor.
 --h3 19.20 <dynamic delete statement: positioned> (p980)
 --/h3
 
---p 
+--p
 Delete a row of a table.
 --/p
 
@@ -5672,7 +5672,7 @@ Delete a row of a table.
 --h3 19.21 <dynamic update statement: positioned> (p982)
 --/h3
 
---p 
+--p
 Update a row of a table.
 --/p
 
@@ -5682,7 +5682,7 @@ Update a row of a table.
 --h3 19.22 <preparable dynamic delete statement: positioned> (p984)
 --/h3
 
---p 
+--p
 Delete a row of a table through a dynamic cursor.
 --/p
 
@@ -5692,7 +5692,7 @@ Delete a row of a table through a dynamic cursor.
 --h3 19.23 <preparable dynamic update statement: positioned> (p986)
 --/h3
 
---p 
+--p
 Update a row of a table through a dynamic cursor.
 --/p
 
@@ -5706,7 +5706,7 @@ Update a row of a table through a dynamic cursor.
 --h3 20.1 <embedded SQL host program> (p989)
 --/h3
 
---p 
+--p
 Specify an <embedded SQL host program>.
 --/p
 
@@ -5789,7 +5789,7 @@ Specify an <embedded SQL host program>.
 --h3 20.2 <embedded exception declaration> (p1001)
 --/h3
 
---p 
+--p
 Specify the action to be taken when an SQL-statement causes a specific class of condition to be
 raised.
 --/p
@@ -5827,7 +5827,7 @@ raised.
 --h3 20.3 <embedded SQL Ada program> (p1005)
 --/h3
 
---p 
+--p
 Specify an <embedded SQL Ada program>.
 --/p
 
@@ -5903,7 +5903,7 @@ Specify an <embedded SQL Ada program>.
 --h3 20.4 <embedded SQL C program> (p1011)
 --/h3
 
---p 
+--p
 Specify an <embedded SQL C program>.
 --/p
 
@@ -6026,7 +6026,7 @@ It is slightly less surprising that the grammar doesn't include C99 keywords suc
 --h3 20.5 <embedded SQL COBOL program> (p1019)
 --/h3
 
---p 
+--p
 Specify an <embedded SQL COBOL program>.
 --/p
 
@@ -6115,7 +6115,7 @@ Specify an <embedded SQL COBOL program>.
 --h3 20.6 <embedded SQL Fortran program> (p1025)
 --/h3
 
---p 
+--p
 Specify an <embedded SQL Fortran program>.
 --/p
 
@@ -6171,7 +6171,7 @@ Specify an <embedded SQL Fortran program>.
 --h3 20.7 <embedded SQL MUMPS program> (p1030)
 --/h3
 
---p 
+--p
 Specify an <embedded SQL MUMPS program>.
 --/p
 
@@ -6231,7 +6231,7 @@ Specify an <embedded SQL MUMPS program>.
 --h3 20.8 <embedded SQL Pascal program> (p1035)
 --/h3
 
---p 
+--p
 Specify an <embedded SQL Pascal program>.
 --/p
 
@@ -6285,7 +6285,7 @@ Specify an <embedded SQL Pascal program>.
 --h3 20.9 <embedded SQL PL/I program> (p1040)
 --/h3
 
---p 
+--p
 Specify an <embedded SQL PL/I program>.
 --/p
 
@@ -6355,7 +6355,7 @@ Specify an <embedded SQL PL/I program>.
 --h3 21.1 <direct SQL statement> (p1047)
 --/h3
 
---p 
+--p
 Specify direct execution of SQL.
 --/p
 
@@ -6382,7 +6382,7 @@ Specify direct execution of SQL.
 --h3 21.2 <direct select statement: multiple rows> (p1051)
 --/h3
 
---p 
+--p
 Specify a statement to retrieve multiple rows from a specified table.
 --/p
 
@@ -6693,7 +6693,7 @@ Table 33 - Implied feature relationships
 --/p
 
 --## <table border=1>
---## <tr><th> Feature ID </th><th> Feature Description </th><th> Implied Feature </th><th> ID Implied Feature Description </th></tr> 
+--## <tr><th> Feature ID </th><th> Feature Description </th><th> Implied Feature </th><th> ID Implied Feature Description </th></tr>
 --## <tr><td> B032 </td><td> Extended dynamic SQL </td><td> B031 </td><td> Basic dynamic SQL </td></tr>
 --## <tr><td> B034 </td><td> Dynamic specification of cursor attributes </td><td> B031 </td><td> Basic dynamic SQL </td></tr>
 --## <tr><td> F381 </td><td> Extended schema manipulation </td><td> F491 </td><td> Constraint management </td></tr>

--- a/sql-2003-2.bnf.html
+++ b/sql-2003-2.bnf.html
@@ -16,9 +16,9 @@
 <br>
 
 <p><font color=green><i><small>
-Derived from file sql-2003-2.bnf version 1.22 dated 2017/11/14 05:32:12
+Derived from file sql-2003-2.bnf version 1.23 dated 2017/11/14 06:53:22
 <br>
-Generated on 2017-11-14 05:32:24+00:00 by file bnf2html.pl version 3.14 dated 2017/11/13 20:42:26
+Generated on 2017-11-14 06:53:25+00:00 by file bnf2html.pl version 3.16 dated 2017/11/14 06:53:22
 </small></i></font></p>
 
 <p>
@@ -12461,6 +12461,10 @@ X
           <a href="#rollback statement"> &lt;rollback statement&gt; </a>
      </td>
 </tr>
+<tr> <td>  <a name="xref-char"> </a> char </td>
+     <td> <a href="#C character type"> &lt;C character type&gt; </a>
+     </td>
+</tr>
 <tr> <td>  <a name="xref-CHAR"> </a> CHAR </td>
      <td> <a href="#Ada qualified type specification"> &lt;Ada qualified type specification&gt; </a>
           <a href="#Ada unqualified type specification"> &lt;Ada unqualified type specification&gt; </a>
@@ -12469,10 +12473,6 @@ X
           <a href="#Pascal type specification"> &lt;Pascal type specification&gt; </a>
           <a href="#PL/I type specification"> &lt;PL/I type specification&gt; </a>
           <a href="#reserved word"> &lt;reserved word&gt; </a>
-     </td>
-</tr>
-<tr> <td>  <a name="xref-char"> </a> char </td>
-     <td> <a href="#C character type"> &lt;C character type&gt; </a>
      </td>
 </tr>
 <tr> <td>  <a name="xref-CHARACTER"> </a> CHARACTER </td>
@@ -13307,14 +13307,14 @@ X
           <a href="#PL/I type fixed decimal"> &lt;PL/I type fixed decimal&gt; </a>
      </td>
 </tr>
-<tr> <td>  <a name="xref-float"> </a> float </td>
-     <td> <a href="#C numeric variable"> &lt;C numeric variable&gt; </a>
-     </td>
-</tr>
 <tr> <td>  <a name="xref-FLOAT"> </a> FLOAT </td>
      <td> <a href="#approximate numeric type"> &lt;approximate numeric type&gt; </a>
           <a href="#PL/I type float binary"> &lt;PL/I type float binary&gt; </a>
           <a href="#reserved word"> &lt;reserved word&gt; </a>
+     </td>
+</tr>
+<tr> <td>  <a name="xref-float"> </a> float </td>
+     <td> <a href="#C numeric variable"> &lt;C numeric variable&gt; </a>
      </td>
 </tr>
 <tr> <td>  <a name="xref-FLOOR"> </a> FLOOR </td>
@@ -15802,8 +15802,7 @@ X
 <p><a href='#top'>Top</a></p>
 
 <hr>
-Please send feedback to Jonathan Leffler, variously:
-<a href="mailto:jonathan.leffler@hcl.com"> jonathan.leffler@hcl.com </a> or
+Please send feedback to Jonathan Leffler:
 <a href="mailto:jonathan.leffler@gmail.com"> jonathan.leffler@gmail.com </a>.
 
 </body>

--- a/sql-2003-2.bnf.html
+++ b/sql-2003-2.bnf.html
@@ -16,9 +16,9 @@
 <br>
 
 <p><font color=green><i><small>
-Derived from file sql-2003-2.bnf version 1.21 dated 2017/10/04 15:15:18
+Derived from file sql-2003-2.bnf version 1.22 dated 2017/11/14 05:32:12
 <br>
-Generated on 2017-10-04 15:17:56+00:00 by file bnf2html.pl version 3.12 dated 2016/04/18 05:13:47
+Generated on 2017-11-14 05:32:24+00:00 by file bnf2html.pl version 3.14 dated 2017/11/13 20:42:26
 </small></i></font></p>
 
 <p>
@@ -217,12 +217,16 @@ Specifying lexical units (tokens and separators) that participate in SQL languag
 <p>
 <i>
 <small>
-Previous standard said:
-<br>
-<p><a href="#xref-identifier start" name="identifier start"> &lt;identifier start&gt; </a>&nbsp;&nbsp;&nbsp;::=&nbsp;&nbsp; <a href='#initial alphabetic character'>&lt;initial alphabetic character&gt;</a>  |  <a href='#ideographic character'>&lt;ideographic character&gt;</a>
+The previous version of the SQL standard defined an identifier start as
+either an &lt;initial alphabetic character&gt; or an &lt;ideographic character&gt;.
+Neither of the defining terms is defined in SQL 2003 (and the SQL 99
+definitions of those defininng terms referred to the syntax rules), but
+the result of the SQL 2003 syntax rules will be similar to SQL 99 ones
+except with Unicode support added.
 </small>
 </i>
 </p>
+<!-- <identifier start> ::= <initial alphabetic character> | <ideographic character> -->
 
 <p><a href="#xref-identifier start" name="identifier start"> &lt;identifier start&gt; </a>&nbsp;&nbsp;&nbsp;::=&nbsp;&nbsp;<font color="red"> !! See the Syntax Rules. </font>
 
@@ -248,7 +252,6 @@ The productions for &lt;Unicode delimited identifier&gt; and so on are new in SQ
 
 <p><a href="#xref-Unicode delimited identifier" name="Unicode delimited identifier"> &lt;Unicode delimited identifier&gt; </a>&nbsp;&nbsp;&nbsp;::=
 <br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-U"> U </a> <a href='#ampersand'>&lt;ampersand&gt;</a> <a href='#double quote'>&lt;double quote&gt;</a>  <a href='#Unicode delimiter body'>&lt;Unicode delimiter body&gt;</a>  <a href='#double quote'>&lt;double quote&gt;</a><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <a href='#Unicode escape specifier'>&lt;Unicode escape specifier&gt;</a>
-
 <p><a href="#xref-Unicode escape specifier" name="Unicode escape specifier"> &lt;Unicode escape specifier&gt; </a>&nbsp;&nbsp;&nbsp;::=&nbsp;&nbsp; [  <a href="#xref-UESCAPE"> UESCAPE </a>  <a href='#quote'>&lt;quote&gt;</a>  <a href='#Unicode escape character'>&lt;Unicode escape character&gt;</a>  <a href='#quote'>&lt;quote&gt;</a>  ]
 
 <p><a href="#xref-Unicode delimiter body" name="Unicode delimiter body"> &lt;Unicode delimiter body&gt; </a>&nbsp;&nbsp;&nbsp;::=&nbsp;&nbsp; <a href='#Unicode identifier part'>&lt;Unicode identifier part&gt;</a> ...
@@ -875,7 +878,6 @@ grammar.
 <hr>
 <h3> 6.11 <a href='#case expression'>&lt;case expression&gt;</a> (p197)
 </h3>
-
 
 <p><a href="#xref-case expression" name="case expression"> &lt;case expression&gt; </a>&nbsp;&nbsp;&nbsp;::=&nbsp;&nbsp; <a href='#case abbreviation'>&lt;case abbreviation&gt;</a>  |  <a href='#case specification'>&lt;case specification&gt;</a>
 
@@ -3374,6 +3376,17 @@ Define an SQL-client module.
 
 <p><a href="#xref-module collation specification" name="module collation specification"> &lt;module collation specification&gt; </a>&nbsp;&nbsp;&nbsp;::=&nbsp;&nbsp; <a href="#xref-COLLATION"> COLLATION </a>  <a href='#collation name'>&lt;collation name&gt;</a>  [  <a href="#xref-FOR"> FOR </a>  <a href='#character set specification list'>&lt;character set specification list&gt;</a>  ]
 
+<p>
+<i>
+<small>
+There was another definition &lt;character set specification list&gt; in section 18.3.
+That was slightly different in format (simpler) but functionally equivalent.
+It is not clear why it was repeated.
+The alternative definition is now commented out.
+</small>
+</i>
+</p>
+
 <p><a href="#xref-character set specification list" name="character set specification list"> &lt;character set specification list&gt; </a>&nbsp;&nbsp;&nbsp;::=&nbsp;&nbsp; <a href='#character set specification'>&lt;character set specification&gt;</a>  [  {  <a href='#comma'>&lt;comma&gt;</a>  <a href='#character set specification'>&lt;character set specification&gt;</a>  }...  ]
 
 <p><a href="#xref-module contents" name="module contents"> &lt;module contents&gt; </a>&nbsp;&nbsp;&nbsp;::=
@@ -4058,7 +4071,14 @@ set.
 
 <p><a href="#xref-set session collation statement" name="set session collation statement"> &lt;set session collation statement&gt; </a>&nbsp;&nbsp;&nbsp;::=
 <br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-SET"> SET </a>  <a href="#xref-COLLATION"> COLLATION </a>  <a href='#collation specification'>&lt;collation specification&gt;</a>  [  <a href="#xref-FOR"> FOR </a>  <a href='#character set specification list'>&lt;character set specification list&gt;</a>  ]<br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-SET"> SET </a>  <a href="#xref-NO"> NO </a>  <a href="#xref-COLLATION"> COLLATION </a>  [  <a href="#xref-FOR"> FOR </a>  <a href='#character set specification list'>&lt;character set specification list&gt;</a>  ]
-<p><a href="#xref-character set specification list" name="character set specification list"> &lt;character set specification list&gt; </a>&nbsp;&nbsp;&nbsp;::=&nbsp;&nbsp; <a href='#character set specification'>&lt;character set specification&gt;</a>  [  ,  <a href='#character set specification'>&lt;character set specification&gt;</a> ...  ]
+<!-- This is a second <character set specification list> definition; the first -->
+<!-- is in section 13.1. -->
+<!-- It is marginally different in detail from the previous version, but the -->
+<!-- overall effect is the same &mdash; a comma-separated list of <character -->
+<!-- set specification> items. -->
+<!-- It isn't clear why there's a repeat of the rule or the difference in the expansion. -->
+<!--  -->
+<!-- <character set specification list> ::= <character set specification> [ , <character set specification>... ] -->
 
 <p><a href="#xref-collation specification" name="collation specification"> &lt;collation specification&gt; </a>&nbsp;&nbsp;&nbsp;::=&nbsp;&nbsp; <a href='#value specification'>&lt;value specification&gt;</a>
 
@@ -4107,6 +4127,15 @@ Get information from an SQL descriptor area.
 
 <p><a href="#xref-get item information" name="get item information"> &lt;get item information&gt; </a>&nbsp;&nbsp;&nbsp;::=&nbsp;&nbsp; <a href='#simple target specification 2'>&lt;simple target specification 2&gt;</a>  <a href='#equals operator'>&lt;equals operator&gt;</a>  <a href='#descriptor item name'>&lt;descriptor item name&gt;</a>
 
+<p>
+<i>
+<small>
+The rule for &lt;item number&gt; was repeated verbatim in section 19.5.
+That rule is now omitted.
+</small>
+</i>
+</p>
+
 <p><a href="#xref-item number" name="item number"> &lt;item number&gt; </a>&nbsp;&nbsp;&nbsp;::=&nbsp;&nbsp; <a href='#simple value specification'>&lt;simple value specification&gt;</a>
 
 <p><a href="#xref-simple target specification 1" name="simple target specification 1"> &lt;simple target specification 1&gt; </a>&nbsp;&nbsp;&nbsp;::=&nbsp;&nbsp; <a href='#simple target specification'>&lt;simple target specification&gt;</a>
@@ -4134,7 +4163,8 @@ Set information in an SQL descriptor area.
 
 <p><a href="#xref-simple value specification 2" name="simple value specification 2"> &lt;simple value specification 2&gt; </a>&nbsp;&nbsp;&nbsp;::=&nbsp;&nbsp; <a href='#simple value specification'>&lt;simple value specification&gt;</a>
 
-<p><a href="#xref-item number" name="item number"> &lt;item number&gt; </a>&nbsp;&nbsp;&nbsp;::=&nbsp;&nbsp; <a href='#simple value specification'>&lt;simple value specification&gt;</a>
+<!-- This <item number> is a repeat of the rule in section 19.4 -->
+<!-- <item number> ::= <simple value specification> -->
 
 <h3> 19.6 <a href='#prepare statement'>&lt;prepare statement&gt;</a> (p941)
 </h3>
@@ -4869,7 +4899,6 @@ returning an implementation-defined subclass in conjunction with one of
 the classes successful completion, warning, or no data.
 </p>
 
-
 <p>
 The 'Category' column has the following meanings: 'S' means that the class value given corresponds
 to successful completion and is a completion condition; 'W' means that the class value given
@@ -5043,7 +5072,6 @@ Table 31 - SQLSTATE class and subclass values
 <tr><td> X </td><td> with check option violation </td><td> 44 </td><td> (no subclass) </td><td> 000 </td></tr>
 </table>
 
-
 <p><a href='#top'>Top</a></p>
 
 <hr>
@@ -5103,7 +5131,6 @@ Table 33 - Implied feature relationships
 <tr><td> T572 </td><td> Multiset-returning external SQLinvoked functions </td><td> S271 </td><td> Basic multiset support </td></tr>
 <tr><td> T612 </td><td> Advanced OLAP operations </td><td> T611 </td><td> Elementary OLAP operations </td></tr>
 </table>
-
 
 <p><a href='#top'>Top</a></p>
 
@@ -7859,10 +7886,6 @@ Z
      <td> <a href="#like options"> &lt;like options&gt; </a>
      </td>
 </tr>
-<tr> <td>  <a href="#ideographic character" name="xref-ideographic character"> ideographic character </a> </td>
-     <td> <a href="#identifier start"> &lt;identifier start&gt; </a>
-     </td>
-</tr>
 <tr> <td>  <a href="#implementation-defined character set name" name="xref-implementation-defined character set name"> implementation-defined character set name </a> </td>
      <td> <a href="#character set specification"> &lt;character set specification&gt; </a>
      </td>
@@ -7908,10 +7931,6 @@ Z
 </tr>
 <tr> <td>  <a href="#indicator variable" name="xref-indicator variable"> indicator variable </a> </td>
      <td> <a href="#embedded variable specification"> &lt;embedded variable specification&gt; </a>
-     </td>
-</tr>
-<tr> <td>  <a href="#initial alphabetic character" name="xref-initial alphabetic character"> initial alphabetic character </a> </td>
-     <td> <a href="#identifier start"> &lt;identifier start&gt; </a>
      </td>
 </tr>
 <tr> <td>  <a href="#input using clause" name="xref-input using clause"> input using clause </a> </td>
@@ -13083,14 +13102,14 @@ X
           <a href="#object name"> &lt;object name&gt; </a>
      </td>
 </tr>
+<tr> <td>  <a name="xref-double"> </a> double </td>
+     <td> <a href="#C numeric variable"> &lt;C numeric variable&gt; </a>
+     </td>
+</tr>
 <tr> <td>  <a name="xref-DOUBLE"> </a> DOUBLE </td>
      <td> <a href="#approximate numeric type"> &lt;approximate numeric type&gt; </a>
           <a href="#Fortran type specification"> &lt;Fortran type specification&gt; </a>
           <a href="#reserved word"> &lt;reserved word&gt; </a>
-     </td>
-</tr>
-<tr> <td>  <a name="xref-double"> </a> double </td>
-     <td> <a href="#C numeric variable"> &lt;C numeric variable&gt; </a>
      </td>
 </tr>
 <tr> <td>  <a name="xref-DOUBLE_PRECISION"> </a> DOUBLE_PRECISION </td>
@@ -13288,14 +13307,14 @@ X
           <a href="#PL/I type fixed decimal"> &lt;PL/I type fixed decimal&gt; </a>
      </td>
 </tr>
+<tr> <td>  <a name="xref-float"> </a> float </td>
+     <td> <a href="#C numeric variable"> &lt;C numeric variable&gt; </a>
+     </td>
+</tr>
 <tr> <td>  <a name="xref-FLOAT"> </a> FLOAT </td>
      <td> <a href="#approximate numeric type"> &lt;approximate numeric type&gt; </a>
           <a href="#PL/I type float binary"> &lt;PL/I type float binary&gt; </a>
           <a href="#reserved word"> &lt;reserved word&gt; </a>
-     </td>
-</tr>
-<tr> <td>  <a name="xref-float"> </a> float </td>
-     <td> <a href="#C numeric variable"> &lt;C numeric variable&gt; </a>
      </td>
 </tr>
 <tr> <td>  <a name="xref-FLOOR"> </a> FLOOR </td>
@@ -15784,7 +15803,7 @@ X
 
 <hr>
 Please send feedback to Jonathan Leffler, variously:
-<a href="mailto:jleffler@us.ibm.com"> jleffler@us.ibm.com </a> or
+<a href="mailto:jonathan.leffler@hcl.com"> jonathan.leffler@hcl.com </a> or
 <a href="mailto:jonathan.leffler@gmail.com"> jonathan.leffler@gmail.com </a>.
 
 </body>

--- a/sql-2003-core-features.html
+++ b/sql-2003-core-features.html
@@ -248,13 +248,12 @@ Derived from Final Committee Draft (FCD) of ISO/IEC 9075-2:2003.
 
 <hr>
 <p>
-Please send feedback to Jonathan Leffler, variously:
-<a href="mailto:jleffler@us.ibm.com"> jleffler@us.ibm.com </a> or
+Please send feedback to Jonathan Leffler:
 <a href="mailto:jonathan.leffler@gmail.com"> jonathan.leffler@gmail.com </a>.
 </p>
 
 <p><font color=green><i><small>
-@(#)$Id: sql-2003-core-features.html,v 1.2 2005/07/18 22:51:48 jleffler Exp $
+@(#)$Id: sql-2003-core-features.html,v 1.3 2017/11/13 20:45:42 jleffler Exp $
 </small></i></font></p>
 
 </body>

--- a/sql-2003-noncore-features.html
+++ b/sql-2003-noncore-features.html
@@ -279,13 +279,12 @@ Derived from Final Committee Draft (FCD) of ISO/IEC 9075-2:2003.
 
 <hr>
 <p>
-Please send feedback to Jonathan Leffler, variously:
-<a href="mailto:jleffler@us.ibm.com"> jleffler@us.ibm.com </a> or
+Please send feedback to Jonathan Leffler:
 <a href="mailto:jonathan.leffler@gmail.com"> jonathan.leffler@gmail.com </a>.
 </p>
 
 <p><font color=green><i><small>
-@(#)$Id: sql-2003-noncore-features.html,v 1.2 2005/07/18 22:51:30 jleffler Exp $
+@(#)$Id: sql-2003-noncore-features.html,v 1.3 2017/11/13 20:45:42 jleffler Exp $
 </small></i></font></p>
 
 </body>

--- a/sql-92.bnf.html
+++ b/sql-92.bnf.html
@@ -18,7 +18,7 @@
 <p><font color=green><i><small>
 Derived from file sql-92.bnf version 2.5 dated 2017/01/17 01:05:03
 <br>
-Generated on 2017-01-17 05:18:33+00:00 by file bnf2html.pl version 3.12 dated 2016/04/18 05:13:47
+Generated on 2017-11-14 05:32:23+00:00 by file bnf2html.pl version 3.14 dated 2017/11/13 20:42:26
 </small></i></font></p>
 
 <p>
@@ -4953,16 +4953,16 @@ X
           <a href="#non-reserved word"> &lt;non-reserved word&gt; </a>
      </td>
 </tr>
-<tr> <td>  <a name="xref-char"> </a> char </td>
-     <td> <a href="#C character variable"> &lt;C character variable&gt; </a>
-     </td>
-</tr>
 <tr> <td>  <a name="xref-CHAR"> </a> CHAR </td>
      <td> <a href="#Ada qualified type specification"> &lt;Ada qualified type specification&gt; </a>
           <a href="#Ada unqualified type specification"> &lt;Ada unqualified type specification&gt; </a>
           <a href="#character string type"> &lt;character string type&gt; </a>
           <a href="#national character string type"> &lt;national character string type&gt; </a>
           <a href="#reserved word"> &lt;reserved word&gt; </a>
+     </td>
+</tr>
+<tr> <td>  <a name="xref-char"> </a> char </td>
+     <td> <a href="#C character variable"> &lt;C character variable&gt; </a>
      </td>
 </tr>
 <tr> <td>  <a name="xref-CHARACTER"> </a> CHARACTER </td>
@@ -5490,13 +5490,13 @@ X
           <a href="#reserved word"> &lt;reserved word&gt; </a>
      </td>
 </tr>
+<tr> <td>  <a name="xref-float"> </a> float </td>
+     <td> <a href="#C numeric variable"> &lt;C numeric variable&gt; </a>
+     </td>
+</tr>
 <tr> <td>  <a name="xref-FLOAT"> </a> FLOAT </td>
      <td> <a href="#approximate numeric type"> &lt;approximate numeric type&gt; </a>
           <a href="#reserved word"> &lt;reserved word&gt; </a>
-     </td>
-</tr>
-<tr> <td>  <a name="xref-float"> </a> float </td>
-     <td> <a href="#C numeric variable"> &lt;C numeric variable&gt; </a>
      </td>
 </tr>
 <tr> <td>  <a name="xref-FOR"> </a> FOR </td>
@@ -6615,7 +6615,7 @@ X
 
 <hr>
 Please send feedback to Jonathan Leffler, variously:
-<a href="mailto:jleffler@us.ibm.com"> jleffler@us.ibm.com </a> or
+<a href="mailto:jonathan.leffler@hcl.com"> jonathan.leffler@hcl.com </a> or
 <a href="mailto:jonathan.leffler@gmail.com"> jonathan.leffler@gmail.com </a>.
 
 </body>

--- a/sql-92.bnf.html
+++ b/sql-92.bnf.html
@@ -18,7 +18,7 @@
 <p><font color=green><i><small>
 Derived from file sql-92.bnf version 2.5 dated 2017/01/17 01:05:03
 <br>
-Generated on 2017-11-14 05:32:23+00:00 by file bnf2html.pl version 3.14 dated 2017/11/13 20:42:26
+Generated on 2017-11-14 06:53:25+00:00 by file bnf2html.pl version 3.16 dated 2017/11/14 06:53:22
 </small></i></font></p>
 
 <p>
@@ -4953,16 +4953,16 @@ X
           <a href="#non-reserved word"> &lt;non-reserved word&gt; </a>
      </td>
 </tr>
+<tr> <td>  <a name="xref-char"> </a> char </td>
+     <td> <a href="#C character variable"> &lt;C character variable&gt; </a>
+     </td>
+</tr>
 <tr> <td>  <a name="xref-CHAR"> </a> CHAR </td>
      <td> <a href="#Ada qualified type specification"> &lt;Ada qualified type specification&gt; </a>
           <a href="#Ada unqualified type specification"> &lt;Ada unqualified type specification&gt; </a>
           <a href="#character string type"> &lt;character string type&gt; </a>
           <a href="#national character string type"> &lt;national character string type&gt; </a>
           <a href="#reserved word"> &lt;reserved word&gt; </a>
-     </td>
-</tr>
-<tr> <td>  <a name="xref-char"> </a> char </td>
-     <td> <a href="#C character variable"> &lt;C character variable&gt; </a>
      </td>
 </tr>
 <tr> <td>  <a name="xref-CHARACTER"> </a> CHARACTER </td>
@@ -5362,13 +5362,13 @@ X
           <a href="#reserved word"> &lt;reserved word&gt; </a>
      </td>
 </tr>
+<tr> <td>  <a name="xref-double"> </a> double </td>
+     <td> <a href="#C numeric variable"> &lt;C numeric variable&gt; </a>
+     </td>
+</tr>
 <tr> <td>  <a name="xref-DOUBLE"> </a> DOUBLE </td>
      <td> <a href="#approximate numeric type"> &lt;approximate numeric type&gt; </a>
           <a href="#reserved word"> &lt;reserved word&gt; </a>
-     </td>
-</tr>
-<tr> <td>  <a name="xref-double"> </a> double </td>
-     <td> <a href="#C numeric variable"> &lt;C numeric variable&gt; </a>
      </td>
 </tr>
 <tr> <td>  <a name="xref-DOUBLE_PRECISION"> </a> DOUBLE_PRECISION </td>
@@ -5490,13 +5490,13 @@ X
           <a href="#reserved word"> &lt;reserved word&gt; </a>
      </td>
 </tr>
-<tr> <td>  <a name="xref-float"> </a> float </td>
-     <td> <a href="#C numeric variable"> &lt;C numeric variable&gt; </a>
-     </td>
-</tr>
 <tr> <td>  <a name="xref-FLOAT"> </a> FLOAT </td>
      <td> <a href="#approximate numeric type"> &lt;approximate numeric type&gt; </a>
           <a href="#reserved word"> &lt;reserved word&gt; </a>
+     </td>
+</tr>
+<tr> <td>  <a name="xref-float"> </a> float </td>
+     <td> <a href="#C numeric variable"> &lt;C numeric variable&gt; </a>
      </td>
 </tr>
 <tr> <td>  <a name="xref-FOR"> </a> FOR </td>
@@ -6614,8 +6614,7 @@ X
 <p><a href='#top'>Top</a></p>
 
 <hr>
-Please send feedback to Jonathan Leffler, variously:
-<a href="mailto:jonathan.leffler@hcl.com"> jonathan.leffler@hcl.com </a> or
+Please send feedback to Jonathan Leffler:
 <a href="mailto:jonathan.leffler@gmail.com"> jonathan.leffler@gmail.com </a>.
 
 </body>

--- a/sql-99.bnf
+++ b/sql-99.bnf
@@ -1,7 +1,7 @@
 BNF Grammar for ISO/IEC 9075:1999 - Database Language SQL (SQL-99)
 ==================================================================
 
-@(#)$Id: sql-99.bnf,v 2.8 2004/07/26 18:00:06 jleffler Exp $
+@(#)$Id: sql-99.bnf,v 2.9 2017/11/14 06:20:28 jleffler Exp $
 
 --p
 Using Appendix G of "SQL:1999 Understanding Relational Language Components" by J
@@ -461,10 +461,12 @@ The lexical analyzer would normally deal with this sort of issue.
 
 <language name> ::= ADA | C | COBOL | FORTRAN | MUMPS | PASCAL | PLI | SQL
 
-<module authorization clause> ::=
-		SCHEMA <schema name>
-	|	AUTHORIZATION <module authorization identifier>
-	|	SCHEMA <schema name> AUTHORIZATION <module authorization identifier>
+--@@ This module authorization clause is superceded by a variant from 9075-5 SQL/Bindings.
+
+--@@ <module authorization clause> ::=
+--@@ 		SCHEMA <schema name>
+--@@ 	|	AUTHORIZATION <module authorization identifier>
+--@@ 	|	SCHEMA <schema name> AUTHORIZATION <module authorization identifier>
 
 <module authorization identifier> ::= <authorization identifier>
 
@@ -1647,7 +1649,8 @@ Normally, the lexical analyzer would return <double colon> as a symbol.
 
 <interval factor> ::= [ <sign> ] <interval primary>
 
-<interval primary> ::= <value expression primary> | <interval value function>
+--@@ This definition of interval primary is superceded by the version from 9075-5 SQL/Bindings
+--@@ <interval primary> ::= <value expression primary> | <interval value function>
 
 <interval value function> ::= <interval absolute value function>
 
@@ -2238,9 +2241,12 @@ used here.
 		[ FOR EACH { ROW | STATEMENT } ]
 		[ WHEN <left paren> <search condition> <right paren> ] <triggered SQL statement>
 
-<triggered SQL statement> ::=
-		<SQL procedure statement>
-	|	BEGIN ATOMIC { <SQL procedure statement> <semicolon> }...  END
+--@@ This definition of triggered SQL statement is superceded by the
+--@@ variant from 9075-4 (SQL/PSM).
+--@@ Consequently, this one is commented out.
+--@@ <triggered SQL statement> ::=
+--@@ 		<SQL procedure statement>
+--@@ 	|	BEGIN ATOMIC { <SQL procedure statement> <semicolon> }...  END
 
 <user-defined type definition> ::= CREATE TYPE <user-defined type body>
 
@@ -3524,6 +3530,17 @@ used here.
 
 <drop module statement> ::= DROP MODULE <SQL-server module name> <drop behavior>
 
+--p
+--small
+--i
+This definition of <triggered SQL statement> is from 9075-4 (SQL/PSM)
+and is documented with:
+--/i
+NOTE 13 – The preceding production defining <triggered SQL statement> completely supersedes the
+definition in ISO/IEC 9075-2.
+--/small
+--/p
+
 <triggered SQL statement> ::= <SQL procedure statement>
 
 --hr
@@ -3644,8 +3661,6 @@ Much, if not all, of the following material comes from ISO/IEC 9075-5:1999, SQL/
 	|	USER_DEFINED_TYPE_SCHEMA
 
 <simple value specification 2> ::= <simple value specification>
-
-<item number> ::= <simple value specification>
 
 <get descriptor statement> ::=
 		GET [ SQL ] DESCRIPTOR <descriptor name> <get descriptor information>
@@ -4405,9 +4420,32 @@ and <right paren> are not designated more accurately.
 
 <host PL/I label variable> ::= !! (See the Syntax Rules.)
 
+--p
+--small
+--i
+This interval primary definition from 9075-5 (SQL/Bindings) is very
+similar to a previous occurrence from 9075-2 (SQL/Foundation), but adds
+the optional interval qualifier.
+The earlier definition is commented out.
+--/i
+--/small
+--/p
+
 <interval primary> ::=
 		<value expression primary> [ <interval qualifier> ]
 	|	<interval value function>
+
+--p
+--small
+--i
+This module authorization clause definition from 9075-5 (SQL/Bindings)
+is similar to a previous occurrence from 9075-2 (SQL/Foundation) but the
+optional 'FOR STATIC ONLY' and 'FOR STATIC AND DYNAMIC' clauses were not
+present before.
+The earlier definition is commented out. 
+--/i
+--/small
+--/p
 
 <module authorization clause> ::=
 		SCHEMA <schema name>

--- a/sql-99.bnf
+++ b/sql-99.bnf
@@ -1,7 +1,7 @@
 BNF Grammar for ISO/IEC 9075:1999 - Database Language SQL (SQL-99)
 ==================================================================
 
-@(#)$Id: sql-99.bnf,v 2.9 2017/11/14 06:20:28 jleffler Exp $
+@(#)$Id: sql-99.bnf,v 2.10 2017/11/14 06:53:22 jleffler Exp $
 
 --p
 Using Appendix G of "SQL:1999 Understanding Relational Language Components" by J
@@ -1480,7 +1480,7 @@ This probably says something about the <slash> <asterisk> and <asterisk>
 
 --p
 --small
---i 
+--i
 Note that <double colon> must be a pair of characters with no
 intervening space, not a pair of colon symbols separated by arbitrary
 white space.
@@ -3779,7 +3779,7 @@ Much, if not all, of the following material comes from ISO/IEC 9075-5:1999, SQL/
 
 --p
 --small
---i 
+--i
 Note that <double period> must be a pair of period characters with no
 intervening space, not a pair of period symbols separated by arbitrary
 white space.
@@ -4442,7 +4442,7 @@ This module authorization clause definition from 9075-5 (SQL/Bindings)
 is similar to a previous occurrence from 9075-2 (SQL/Foundation) but the
 optional 'FOR STATIC ONLY' and 'FOR STATIC AND DYNAMIC' clauses were not
 present before.
-The earlier definition is commented out. 
+The earlier definition is commented out.
 --/i
 --/small
 --/p

--- a/sql-99.bnf.html
+++ b/sql-99.bnf.html
@@ -16,9 +16,9 @@
 <br>
 
 <p><font color=green><i><small>
-Derived from file sql-99.bnf version 2.9 dated 2017/11/14 06:20:28
+Derived from file sql-99.bnf version 2.10 dated 2017/11/14 06:53:22
 <br>
-Generated on 2017-11-14 06:20:30+00:00 by file bnf2html.pl version 3.14 dated 2017/11/13 20:42:26
+Generated on 2017-11-14 06:53:25+00:00 by file bnf2html.pl version 3.16 dated 2017/11/14 06:53:22
 </small></i></font></p>
 
 <p>
@@ -10211,6 +10211,10 @@ X
           <a href="#rollback statement"> &lt;rollback statement&gt; </a>
      </td>
 </tr>
+<tr> <td>  <a name="xref-char"> </a> char </td>
+     <td> <a href="#C character type"> &lt;C character type&gt; </a>
+     </td>
+</tr>
 <tr> <td>  <a name="xref-CHAR"> </a> CHAR </td>
      <td> <a href="#Ada qualified type specification"> &lt;Ada qualified type specification&gt; </a>
           <a href="#Ada unqualified type specification"> &lt;Ada unqualified type specification&gt; </a>
@@ -10219,10 +10223,6 @@ X
           <a href="#Pascal type specification"> &lt;Pascal type specification&gt; </a>
           <a href="#PL/I type specification"> &lt;PL/I type specification&gt; </a>
           <a href="#reserved word"> &lt;reserved word&gt; </a>
-     </td>
-</tr>
-<tr> <td>  <a name="xref-char"> </a> char </td>
-     <td> <a href="#C character type"> &lt;C character type&gt; </a>
      </td>
 </tr>
 <tr> <td>  <a name="xref-CHARACTER"> </a> CHARACTER </td>
@@ -10430,13 +10430,13 @@ X
           <a href="#non-reserved word"> &lt;non-reserved word&gt; </a>
      </td>
 </tr>
-<tr> <td>  <a name="xref-Connect"> </a> Connect </td>
-     <td> <a href="#CLI generic name"> &lt;CLI generic name&gt; </a>
-     </td>
-</tr>
 <tr> <td>  <a name="xref-CONNECT"> </a> CONNECT </td>
      <td> <a href="#connect statement"> &lt;connect statement&gt; </a>
           <a href="#reserved word"> &lt;reserved word&gt; </a>
+     </td>
+</tr>
+<tr> <td>  <a name="xref-Connect"> </a> Connect </td>
+     <td> <a href="#CLI generic name"> &lt;CLI generic name&gt; </a>
      </td>
 </tr>
 <tr> <td>  <a name="xref-CONNECTION"> </a> CONNECTION </td>
@@ -10865,14 +10865,14 @@ X
           <a href="#reserved word"> &lt;reserved word&gt; </a>
      </td>
 </tr>
-<tr> <td>  <a name="xref-double"> </a> double </td>
-     <td> <a href="#C numeric variable"> &lt;C numeric variable&gt; </a>
-     </td>
-</tr>
 <tr> <td>  <a name="xref-DOUBLE"> </a> DOUBLE </td>
      <td> <a href="#approximate numeric type"> &lt;approximate numeric type&gt; </a>
           <a href="#Fortran type specification"> &lt;Fortran type specification&gt; </a>
           <a href="#reserved word"> &lt;reserved word&gt; </a>
+     </td>
+</tr>
+<tr> <td>  <a name="xref-double"> </a> double </td>
+     <td> <a href="#C numeric variable"> &lt;C numeric variable&gt; </a>
      </td>
 </tr>
 <tr> <td>  <a name="xref-DOUBLE_PRECISION"> </a> DOUBLE_PRECISION </td>
@@ -11057,15 +11057,15 @@ X
      <td> <a href="#CLI generic name"> &lt;CLI generic name&gt; </a>
      </td>
 </tr>
-<tr> <td>  <a name="xref-Execute"> </a> Execute </td>
-     <td> <a href="#CLI generic name"> &lt;CLI generic name&gt; </a>
-     </td>
-</tr>
 <tr> <td>  <a name="xref-EXECUTE"> </a> EXECUTE </td>
      <td> <a href="#action"> &lt;action&gt; </a>
           <a href="#execute immediate statement"> &lt;execute immediate statement&gt; </a>
           <a href="#execute statement"> &lt;execute statement&gt; </a>
           <a href="#reserved word"> &lt;reserved word&gt; </a>
+     </td>
+</tr>
+<tr> <td>  <a name="xref-Execute"> </a> Execute </td>
+     <td> <a href="#CLI generic name"> &lt;CLI generic name&gt; </a>
      </td>
 </tr>
 <tr> <td>  <a name="xref-EXISTS"> </a> EXISTS </td>
@@ -11099,14 +11099,14 @@ X
           <a href="#truth value"> &lt;truth value&gt; </a>
      </td>
 </tr>
+<tr> <td>  <a name="xref-Fetch"> </a> Fetch </td>
+     <td> <a href="#CLI generic name"> &lt;CLI generic name&gt; </a>
+     </td>
+</tr>
 <tr> <td>  <a name="xref-FETCH"> </a> FETCH </td>
      <td> <a href="#dynamic fetch statement"> &lt;dynamic fetch statement&gt; </a>
           <a href="#fetch statement"> &lt;fetch statement&gt; </a>
           <a href="#reserved word"> &lt;reserved word&gt; </a>
-     </td>
-</tr>
-<tr> <td>  <a name="xref-Fetch"> </a> Fetch </td>
-     <td> <a href="#CLI generic name"> &lt;CLI generic name&gt; </a>
      </td>
 </tr>
 <tr> <td>  <a name="xref-FetchScroll"> </a> FetchScroll </td>
@@ -11129,14 +11129,14 @@ X
           <a href="#PL/I type fixed decimal"> &lt;PL/I type fixed decimal&gt; </a>
      </td>
 </tr>
+<tr> <td>  <a name="xref-float"> </a> float </td>
+     <td> <a href="#C numeric variable"> &lt;C numeric variable&gt; </a>
+     </td>
+</tr>
 <tr> <td>  <a name="xref-FLOAT"> </a> FLOAT </td>
      <td> <a href="#approximate numeric type"> &lt;approximate numeric type&gt; </a>
           <a href="#PL/I type float binary"> &lt;PL/I type float binary&gt; </a>
           <a href="#reserved word"> &lt;reserved word&gt; </a>
-     </td>
-</tr>
-<tr> <td>  <a name="xref-float"> </a> float </td>
-     <td> <a href="#C numeric variable"> &lt;C numeric variable&gt; </a>
      </td>
 </tr>
 <tr> <td>  <a name="xref-FOR"> </a> FOR </td>
@@ -11995,11 +11995,6 @@ X
      <td> <a href="#CLI generic name"> &lt;CLI generic name&gt; </a>
      </td>
 </tr>
-<tr> <td>  <a name="xref-No"> </a> No </td>
-     <td> <a href="#Package PKG(i)"> &lt;Package PKG(i)&gt; </a>
-          <a href="#Part (n) no"> &lt;Part (n) no&gt; </a>
-     </td>
-</tr>
 <tr> <td>  <a name="xref-NO"> </a> NO </td>
      <td> <a href="#commit statement"> &lt;commit statement&gt; </a>
           <a href="#cursor scrollability"> &lt;cursor scrollability&gt; </a>
@@ -12012,6 +12007,11 @@ X
 </tr>
 <tr> <td>  <a name="xref-no"> </a> no </td>
      <td> <a href="#Part (n)"> &lt;Part (n)&gt; </a>
+     </td>
+</tr>
+<tr> <td>  <a name="xref-No"> </a> No </td>
+     <td> <a href="#Package PKG(i)"> &lt;Package PKG(i)&gt; </a>
+          <a href="#Part (n) no"> &lt;Part (n) no&gt; </a>
      </td>
 </tr>
 <tr> <td>  <a name="xref-NONE"> </a> NONE </td>
@@ -12335,14 +12335,14 @@ X
           <a href="#reserved word"> &lt;reserved word&gt; </a>
      </td>
 </tr>
-<tr> <td>  <a name="xref-Prepare"> </a> Prepare </td>
-     <td> <a href="#CLI generic name"> &lt;CLI generic name&gt; </a>
-     </td>
-</tr>
 <tr> <td>  <a name="xref-PREPARE"> </a> PREPARE </td>
      <td> <a href="#deallocate prepared statement"> &lt;deallocate prepared statement&gt; </a>
           <a href="#prepare statement"> &lt;prepare statement&gt; </a>
           <a href="#reserved word"> &lt;reserved word&gt; </a>
+     </td>
+</tr>
+<tr> <td>  <a name="xref-Prepare"> </a> Prepare </td>
+     <td> <a href="#CLI generic name"> &lt;CLI generic name&gt; </a>
      </td>
 </tr>
 <tr> <td>  <a name="xref-PRESERVE"> </a> PRESERVE </td>
@@ -13604,8 +13604,7 @@ X
 <p><a href='#top'>Top</a></p>
 
 <hr>
-Please send feedback to Jonathan Leffler, variously:
-<a href="mailto:jonathan.leffler@hcl.com"> jonathan.leffler@hcl.com </a> or
+Please send feedback to Jonathan Leffler:
 <a href="mailto:jonathan.leffler@gmail.com"> jonathan.leffler@gmail.com </a>.
 
 </body>

--- a/sql-99.bnf.html
+++ b/sql-99.bnf.html
@@ -16,9 +16,9 @@
 <br>
 
 <p><font color=green><i><small>
-Derived from file sql-99.bnf version 2.8 dated 2004/07/26 18:00:06
+Derived from file sql-99.bnf version 2.9 dated 2017/11/14 06:20:28
 <br>
-Generated on 2017-01-17 05:18:34+00:00 by file bnf2html.pl version 3.12 dated 2016/04/18 05:13:47
+Generated on 2017-11-14 06:20:30+00:00 by file bnf2html.pl version 3.14 dated 2017/11/13 20:42:26
 </small></i></font></p>
 
 <p>
@@ -427,8 +427,13 @@ The lexical analyzer would normally deal with this sort of issue.
 
 <p><a href="#xref-language name" name="language name"> &lt;language name&gt; </a>&nbsp;&nbsp;&nbsp;::=&nbsp;&nbsp; <a href="#xref-ADA"> ADA </a>  |  <a href="#xref-C"> C </a>  |  <a href="#xref-COBOL"> COBOL </a>  |  <a href="#xref-FORTRAN"> FORTRAN </a>  |  <a href="#xref-MUMPS"> MUMPS </a>  |  <a href="#xref-PASCAL"> PASCAL </a>  |  <a href="#xref-PLI"> PLI </a>  |  <a href="#xref-SQL"> SQL </a>
 
-<p><a href="#xref-module authorization clause" name="module authorization clause"> &lt;module authorization clause&gt; </a>&nbsp;&nbsp;&nbsp;::=
-<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-SCHEMA"> SCHEMA </a>  <a href='#schema name'>&lt;schema name&gt;</a><br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-AUTHORIZATION"> AUTHORIZATION </a>  <a href='#module authorization identifier'>&lt;module authorization identifier&gt;</a><br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-SCHEMA"> SCHEMA </a>  <a href='#schema name'>&lt;schema name&gt;</a>  <a href="#xref-AUTHORIZATION"> AUTHORIZATION </a>  <a href='#module authorization identifier'>&lt;module authorization identifier&gt;</a>
+<!-- This module authorization clause is superceded by a variant from 9075-5 SQL/Bindings. -->
+
+<!-- <module authorization clause> ::= -->
+<!-- SCHEMA <schema name> -->
+<!-- |       AUTHORIZATION <module authorization identifier> -->
+<!-- |       SCHEMA <schema name> AUTHORIZATION <module authorization identifier> -->
+
 <p><a href="#xref-module authorization identifier" name="module authorization identifier"> &lt;module authorization identifier&gt; </a>&nbsp;&nbsp;&nbsp;::=&nbsp;&nbsp; <a href='#authorization identifier'>&lt;authorization identifier&gt;</a>
 
 <p><a href="#xref-authorization identifier" name="authorization identifier"> &lt;authorization identifier&gt; </a>&nbsp;&nbsp;&nbsp;::=&nbsp;&nbsp; <a href='#role name'>&lt;role name&gt;</a>  |  <a href='#user identifier'>&lt;user identifier&gt;</a>
@@ -1314,7 +1319,8 @@ Normally, the lexical analyzer would return &lt;double colon&gt; as a symbol.
 <br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <a href='#interval factor'>&lt;interval factor&gt;</a><br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href='#interval term 2'>&lt;interval term 2&gt;</a>  <a href='#asterisk'>&lt;asterisk&gt;</a>  <a href='#factor'>&lt;factor&gt;</a><br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href='#interval term 2'>&lt;interval term 2&gt;</a>  <a href='#solidus'>&lt;solidus&gt;</a>  <a href='#factor'>&lt;factor&gt;</a><br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href='#term'>&lt;term&gt;</a>  <a href='#asterisk'>&lt;asterisk&gt;</a>  <a href='#interval factor'>&lt;interval factor&gt;</a>
 <p><a href="#xref-interval factor" name="interval factor"> &lt;interval factor&gt; </a>&nbsp;&nbsp;&nbsp;::=&nbsp;&nbsp; [  <a href='#sign'>&lt;sign&gt;</a>  ]  <a href='#interval primary'>&lt;interval primary&gt;</a>
 
-<p><a href="#xref-interval primary" name="interval primary"> &lt;interval primary&gt; </a>&nbsp;&nbsp;&nbsp;::=&nbsp;&nbsp; <a href='#value expression primary'>&lt;value expression primary&gt;</a>  |  <a href='#interval value function'>&lt;interval value function&gt;</a>
+<!-- This definition of interval primary is superceded by the version from 9075-5 SQL/Bindings -->
+<!-- <interval primary> ::= <value expression primary> | <interval value function> -->
 
 <p><a href="#xref-interval value function" name="interval value function"> &lt;interval value function&gt; </a>&nbsp;&nbsp;&nbsp;::=&nbsp;&nbsp; <a href='#interval absolute value function'>&lt;interval absolute value function&gt;</a>
 
@@ -1763,8 +1769,13 @@ used here.
 
 <p><a href="#xref-triggered action" name="triggered action"> &lt;triggered action&gt; </a>&nbsp;&nbsp;&nbsp;::=
 <br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [  <a href="#xref-FOR"> FOR </a>  <a href="#xref-EACH"> EACH </a>  {  <a href="#xref-ROW"> ROW </a>  |  <a href="#xref-STATEMENT"> STATEMENT </a>  }  ]<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [  <a href="#xref-WHEN"> WHEN </a>  <a href='#left paren'>&lt;left paren&gt;</a>  <a href='#search condition'>&lt;search condition&gt;</a>  <a href='#right paren'>&lt;right paren&gt;</a>  ]  <a href='#triggered SQL statement'>&lt;triggered SQL statement&gt;</a>
-<p><a href="#xref-triggered SQL statement" name="triggered SQL statement"> &lt;triggered SQL statement&gt; </a>&nbsp;&nbsp;&nbsp;::=
-<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <a href='#SQL procedure statement'>&lt;SQL procedure statement&gt;</a><br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-BEGIN"> BEGIN </a>  <a href="#xref-ATOMIC"> ATOMIC </a>  {  <a href='#SQL procedure statement'>&lt;SQL procedure statement&gt;</a>  <a href='#semicolon'>&lt;semicolon&gt;</a>  }...   <a href="#xref-END"> END </a>
+<!-- This definition of triggered SQL statement is superceded by the -->
+<!-- variant from 9075-4 (SQL/PSM). -->
+<!-- Consequently, this one is commented out. -->
+<!-- <triggered SQL statement> ::= -->
+<!-- <SQL procedure statement> -->
+<!-- |       BEGIN ATOMIC { <SQL procedure statement> <semicolon> }...  END -->
+
 <p><a href="#xref-user-defined type definition" name="user-defined type definition"> &lt;user-defined type definition&gt; </a>&nbsp;&nbsp;&nbsp;::=&nbsp;&nbsp; <a href="#xref-CREATE"> CREATE </a>  <a href="#xref-TYPE"> TYPE </a>  <a href='#user-defined type body'>&lt;user-defined type body&gt;</a>
 
 <p>
@@ -2618,6 +2629,17 @@ used here.
 
 <p><a href="#xref-drop module statement" name="drop module statement"> &lt;drop module statement&gt; </a>&nbsp;&nbsp;&nbsp;::=&nbsp;&nbsp; <a href="#xref-DROP"> DROP </a>  <a href="#xref-MODULE"> MODULE </a>  <a href='#SQL-server module name'>&lt;SQL-server module name&gt;</a>  <a href='#drop behavior'>&lt;drop behavior&gt;</a>
 
+<p>
+<small>
+<i>
+This definition of &lt;triggered SQL statement&gt; is from 9075-4 (SQL/PSM)
+and is documented with:
+</i>
+NOTE 13 – The preceding production defining &lt;triggered SQL statement&gt; completely supersedes the
+definition in ISO/IEC 9075-2.
+</small>
+</p>
+
 <p><a href="#xref-triggered SQL statement" name="triggered SQL statement"> &lt;triggered SQL statement&gt; </a>&nbsp;&nbsp;&nbsp;::=&nbsp;&nbsp; <a href='#SQL procedure statement'>&lt;SQL procedure statement&gt;</a>
 
 <p><a href='#top'>Top</a></p>
@@ -2679,8 +2701,6 @@ Much, if not all, of the following material comes from ISO/IEC 9075-5:1999, SQL/
 <p><a href="#xref-descriptor item name" name="descriptor item name"> &lt;descriptor item name&gt; </a>&nbsp;&nbsp;&nbsp;::=
 <br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-CARDINALITY"> CARDINALITY </a><br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-CHARACTER_SET_CATALOG"> CHARACTER_SET_CATALOG </a><br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-CHARACTER_SET_NAME"> CHARACTER_SET_NAME </a><br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-CHARACTER_SET_SCHEMA"> CHARACTER_SET_SCHEMA </a><br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-COLLATION_CATALOG"> COLLATION_CATALOG </a><br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-COLLATION_NAME"> COLLATION_NAME </a><br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-COLLATION_SCHEMA"> COLLATION_SCHEMA </a><br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-DATA"> DATA </a><br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-DATETIME_INTERVAL_CODE"> DATETIME_INTERVAL_CODE </a><br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-DATETIME_INTERVAL_PRECISION"> DATETIME_INTERVAL_PRECISION </a><br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-DEGREE"> DEGREE </a><br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-INDICATOR"> INDICATOR </a><br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-KEY_MEMBER"> KEY_MEMBER </a><br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-LENGTH"> LENGTH </a><br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-LEVEL"> LEVEL </a><br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-NAME"> NAME </a><br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-NULLABLE"> NULLABLE </a><br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-OCTET_LENGTH"> OCTET_LENGTH </a><br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-PARAMETER_MODE"> PARAMETER_MODE </a><br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-PARAMETER_ORDINAL_POSITION"> PARAMETER_ORDINAL_POSITION </a><br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-PARAMETER_SPECIFIC_CATALOG"> PARAMETER_SPECIFIC_CATALOG </a><br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-PARAMETER_SPECIFIC_NAME"> PARAMETER_SPECIFIC_NAME </a><br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-PARAMETER_SPECIFIC_SCHEMA"> PARAMETER_SPECIFIC_SCHEMA </a><br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-PRECISION"> PRECISION </a><br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-RETURNED_CARDINALITY"> RETURNED_CARDINALITY </a><br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-RETURNED_LENGTH"> RETURNED_LENGTH </a><br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-RETURNED_OCTET_LENGTH"> RETURNED_OCTET_LENGTH </a><br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-SCALE"> SCALE </a><br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-SCOPE_CATALOG"> SCOPE_CATALOG </a><br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-SCOPE_NAME"> SCOPE_NAME </a><br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-SCOPE_SCHEMA"> SCOPE_SCHEMA </a><br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-TYPE"> TYPE </a><br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-UNNAMED"> UNNAMED </a><br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-USER_DEFINED_TYPE_CATALOG"> USER_DEFINED_TYPE_CATALOG </a><br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-USER_DEFINED_TYPE_NAME"> USER_DEFINED_TYPE_NAME </a><br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-USER_DEFINED_TYPE_SCHEMA"> USER_DEFINED_TYPE_SCHEMA </a>
 <p><a href="#xref-simple value specification 2" name="simple value specification 2"> &lt;simple value specification 2&gt; </a>&nbsp;&nbsp;&nbsp;::=&nbsp;&nbsp; <a href='#simple value specification'>&lt;simple value specification&gt;</a>
-
-<p><a href="#xref-item number" name="item number"> &lt;item number&gt; </a>&nbsp;&nbsp;&nbsp;::=&nbsp;&nbsp; <a href='#simple value specification'>&lt;simple value specification&gt;</a>
 
 <p><a href="#xref-get descriptor statement" name="get descriptor statement"> &lt;get descriptor statement&gt; </a>&nbsp;&nbsp;&nbsp;::=
 <br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-GET"> GET </a>  [  <a href="#xref-SQL"> SQL </a>  ]  <a href="#xref-DESCRIPTOR"> DESCRIPTOR </a>  <a href='#descriptor name'>&lt;descriptor name&gt;</a>  <a href='#get descriptor information'>&lt;get descriptor information&gt;</a>
@@ -3123,8 +3143,31 @@ and &lt;right paren&gt; are not designated more accurately.
 
 <p><a href="#xref-host PL/I label variable" name="host PL/I label variable"> &lt;host PL/I label variable&gt; </a>&nbsp;&nbsp;&nbsp;::=&nbsp;&nbsp;<font color="red"> !! (See the Syntax Rules.) </font>
 
+<p>
+<small>
+<i>
+This interval primary definition from 9075-5 (SQL/Bindings) is very
+similar to a previous occurrence from 9075-2 (SQL/Foundation), but adds
+the optional interval qualifier.
+The earlier definition is commented out.
+</i>
+</small>
+</p>
+
 <p><a href="#xref-interval primary" name="interval primary"> &lt;interval primary&gt; </a>&nbsp;&nbsp;&nbsp;::=
 <br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <a href='#value expression primary'>&lt;value expression primary&gt;</a>  [  <a href='#interval qualifier'>&lt;interval qualifier&gt;</a>  ]<br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href='#interval value function'>&lt;interval value function&gt;</a>
+<p>
+<small>
+<i>
+This module authorization clause definition from 9075-5 (SQL/Bindings)
+is similar to a previous occurrence from 9075-2 (SQL/Foundation) but the
+optional 'FOR STATIC ONLY' and 'FOR STATIC AND DYNAMIC' clauses were not
+present before.
+The earlier definition is commented out.
+</i>
+</small>
+</p>
+
 <p><a href="#xref-module authorization clause" name="module authorization clause"> &lt;module authorization clause&gt; </a>&nbsp;&nbsp;&nbsp;::=
 <br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-SCHEMA"> SCHEMA </a>  <a href='#schema name'>&lt;schema name&gt;</a><br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-AUTHORIZATION"> AUTHORIZATION </a>  <a href='#module authorization identifier'>&lt;module authorization identifier&gt;</a><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [  <a href="#xref-FOR"> FOR </a>  <a href="#xref-STATIC"> STATIC </a>  {  <a href="#xref-ONLY"> ONLY </a>  |  <a href="#xref-AND"> AND </a>  <a href="#xref-DYNAMIC"> DYNAMIC </a>  }  ]<br>&nbsp;&nbsp;&nbsp;&nbsp; |&nbsp;&nbsp;&nbsp;&nbsp; <a href="#xref-SCHEMA"> SCHEMA </a>  <a href='#schema name'>&lt;schema name&gt;</a>  <a href="#xref-AUTHORIZATION"> AUTHORIZATION </a>  <a href='#module authorization identifier'>&lt;module authorization identifier&gt;</a><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [  <a href="#xref-FOR"> FOR </a>  <a href="#xref-STATIC"> STATIC </a>  {  <a href="#xref-ONLY"> ONLY </a>  |  <a href="#xref-AND"> AND </a>  <a href="#xref-DYNAMIC"> DYNAMIC </a>  }  ]
 <p><a href="#xref-preparable statement" name="preparable statement"> &lt;preparable statement&gt; </a>&nbsp;&nbsp;&nbsp;::=
@@ -8226,7 +8269,6 @@ Z
           <a href="#terminated local declaration"> &lt;terminated local declaration&gt; </a>
           <a href="#terminated local handler declaration"> &lt;terminated local handler declaration&gt; </a>
           <a href="#terminated SQL statement"> &lt;terminated SQL statement&gt; </a>
-          <a href="#triggered SQL statement"> &lt;triggered SQL statement&gt; </a>
      </td>
 </tr>
 <tr> <td>  <a href="#separator" name="xref-separator"> separator </a> </td>
@@ -9964,7 +10006,6 @@ X
 <tr> <td>  <a name="xref-ATOMIC"> </a> ATOMIC </td>
      <td> <a href="#compound statement"> &lt;compound statement&gt; </a>
           <a href="#non-reserved word"> &lt;non-reserved word&gt; </a>
-          <a href="#triggered SQL statement"> &lt;triggered SQL statement&gt; </a>
      </td>
 </tr>
 <tr> <td>  <a name="xref-ATTRIBUTE"> </a> ATTRIBUTE </td>
@@ -10000,7 +10041,6 @@ X
           <a href="#embedded SQL begin declare"> &lt;embedded SQL begin declare&gt; </a>
           <a href="#embedded SQL MUMPS declare"> &lt;embedded SQL MUMPS declare&gt; </a>
           <a href="#reserved word"> &lt;reserved word&gt; </a>
-          <a href="#triggered SQL statement"> &lt;triggered SQL statement&gt; </a>
      </td>
 </tr>
 <tr> <td>  <a name="xref-BETWEEN"> </a> BETWEEN </td>
@@ -10390,13 +10430,13 @@ X
           <a href="#non-reserved word"> &lt;non-reserved word&gt; </a>
      </td>
 </tr>
+<tr> <td>  <a name="xref-Connect"> </a> Connect </td>
+     <td> <a href="#CLI generic name"> &lt;CLI generic name&gt; </a>
+     </td>
+</tr>
 <tr> <td>  <a name="xref-CONNECT"> </a> CONNECT </td>
      <td> <a href="#connect statement"> &lt;connect statement&gt; </a>
           <a href="#reserved word"> &lt;reserved word&gt; </a>
-     </td>
-</tr>
-<tr> <td>  <a name="xref-Connect"> </a> Connect </td>
-     <td> <a href="#CLI generic name"> &lt;CLI generic name&gt; </a>
      </td>
 </tr>
 <tr> <td>  <a name="xref-CONNECTION"> </a> CONNECTION </td>
@@ -10783,13 +10823,13 @@ X
      <td> <a href="#Part 5 direct yes"> &lt;Part 5 direct yes&gt; </a>
      </td>
 </tr>
-<tr> <td>  <a name="xref-Disconnect"> </a> Disconnect </td>
-     <td> <a href="#CLI generic name"> &lt;CLI generic name&gt; </a>
-     </td>
-</tr>
 <tr> <td>  <a name="xref-DISCONNECT"> </a> DISCONNECT </td>
      <td> <a href="#disconnect statement"> &lt;disconnect statement&gt; </a>
           <a href="#reserved word"> &lt;reserved word&gt; </a>
+     </td>
+</tr>
+<tr> <td>  <a name="xref-Disconnect"> </a> Disconnect </td>
+     <td> <a href="#CLI generic name"> &lt;CLI generic name&gt; </a>
      </td>
 </tr>
 <tr> <td>  <a name="xref-DISPATCH"> </a> DISPATCH </td>
@@ -10964,7 +11004,6 @@ X
           <a href="#simple case"> &lt;simple case&gt; </a>
           <a href="#simple case statement"> &lt;simple case statement&gt; </a>
           <a href="#SQL-server module definition"> &lt;SQL-server module definition&gt; </a>
-          <a href="#triggered SQL statement"> &lt;triggered SQL statement&gt; </a>
           <a href="#while statement"> &lt;while statement&gt; </a>
      </td>
 </tr>
@@ -11060,14 +11099,14 @@ X
           <a href="#truth value"> &lt;truth value&gt; </a>
      </td>
 </tr>
-<tr> <td>  <a name="xref-Fetch"> </a> Fetch </td>
-     <td> <a href="#CLI generic name"> &lt;CLI generic name&gt; </a>
-     </td>
-</tr>
 <tr> <td>  <a name="xref-FETCH"> </a> FETCH </td>
      <td> <a href="#dynamic fetch statement"> &lt;dynamic fetch statement&gt; </a>
           <a href="#fetch statement"> &lt;fetch statement&gt; </a>
           <a href="#reserved word"> &lt;reserved word&gt; </a>
+     </td>
+</tr>
+<tr> <td>  <a name="xref-Fetch"> </a> Fetch </td>
+     <td> <a href="#CLI generic name"> &lt;CLI generic name&gt; </a>
      </td>
 </tr>
 <tr> <td>  <a name="xref-FetchScroll"> </a> FetchScroll </td>
@@ -11090,14 +11129,14 @@ X
           <a href="#PL/I type fixed decimal"> &lt;PL/I type fixed decimal&gt; </a>
      </td>
 </tr>
-<tr> <td>  <a name="xref-float"> </a> float </td>
-     <td> <a href="#C numeric variable"> &lt;C numeric variable&gt; </a>
-     </td>
-</tr>
 <tr> <td>  <a name="xref-FLOAT"> </a> FLOAT </td>
      <td> <a href="#approximate numeric type"> &lt;approximate numeric type&gt; </a>
           <a href="#PL/I type float binary"> &lt;PL/I type float binary&gt; </a>
           <a href="#reserved word"> &lt;reserved word&gt; </a>
+     </td>
+</tr>
+<tr> <td>  <a name="xref-float"> </a> float </td>
+     <td> <a href="#C numeric variable"> &lt;C numeric variable&gt; </a>
      </td>
 </tr>
 <tr> <td>  <a name="xref-FOR"> </a> FOR </td>
@@ -11961,10 +12000,6 @@ X
           <a href="#Part (n) no"> &lt;Part (n) no&gt; </a>
      </td>
 </tr>
-<tr> <td>  <a name="xref-no"> </a> no </td>
-     <td> <a href="#Part (n)"> &lt;Part (n)&gt; </a>
-     </td>
-</tr>
 <tr> <td>  <a name="xref-NO"> </a> NO </td>
      <td> <a href="#commit statement"> &lt;commit statement&gt; </a>
           <a href="#cursor scrollability"> &lt;cursor scrollability&gt; </a>
@@ -11973,6 +12008,10 @@ X
           <a href="#reserved word"> &lt;reserved word&gt; </a>
           <a href="#rollback statement"> &lt;rollback statement&gt; </a>
           <a href="#SQL-data access indication"> &lt;SQL-data access indication&gt; </a>
+     </td>
+</tr>
+<tr> <td>  <a name="xref-no"> </a> no </td>
+     <td> <a href="#Part (n)"> &lt;Part (n)&gt; </a>
      </td>
 </tr>
 <tr> <td>  <a name="xref-NONE"> </a> NONE </td>
@@ -13545,12 +13584,12 @@ X
           <a href="#reserved word"> &lt;reserved word&gt; </a>
      </td>
 </tr>
-<tr> <td>  <a name="xref-Yes"> </a> Yes </td>
-     <td> <a href="#Package PKG(i)"> &lt;Package PKG(i)&gt; </a>
-     </td>
-</tr>
 <tr> <td>  <a name="xref-yes"> </a> yes </td>
      <td> <a href="#Part (n)"> &lt;Part (n)&gt; </a>
+     </td>
+</tr>
+<tr> <td>  <a name="xref-Yes"> </a> Yes </td>
+     <td> <a href="#Package PKG(i)"> &lt;Package PKG(i)&gt; </a>
      </td>
 </tr>
 <tr> <td> <a name="keywords-Z"> </a> <a name="xref-ZONE"> </a> ZONE </td>
@@ -13566,7 +13605,7 @@ X
 
 <hr>
 Please send feedback to Jonathan Leffler, variously:
-<a href="mailto:jleffler@us.ibm.com"> jleffler@us.ibm.com </a> or
+<a href="mailto:jonathan.leffler@hcl.com"> jonathan.leffler@hcl.com </a> or
 <a href="mailto:jonathan.leffler@gmail.com"> jonathan.leffler@gmail.com </a>.
 
 </body>


### PR DESCRIPTION
Finish the fix for duplicate rules.
    
Upgrade the `bnf2html.pl` script to spot repeated rule definitions.
Update `sql-2003-2.bnf` and `sql-99.bnf` to eliminate various repeated
rules.  The repeats in SQL-99 mostly come from extra information in
9075-4 (SQL/PSM) and 9075-5 (SQL/Bindings).  The repeat in SQL-2003-2
was similar.
    
Also, update contact information.
Also, strip trailing blanks.
