### PR TITLE
Fixed Typo and modification date

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Also available:
 ## Informix OUTER Join Syntax
 
 The file [`outer-joins.html`](outer-joins.html) is an explanation of the
-non-standar Informix OUTER join syntax and semantics.
+non-standard Informix OUTER join syntax and semantics.
 
 ## Conversion tools
 


### PR DESCRIPTION
The previous version had "non-standar Informix" instead of "non-standard Informix"

I'm also curious about the need for the Informix paragraph as the 

The document http://informixsoftware.com/ids117/Guide%20to%20SQL%20Tutorial%20Version%20117.pdf  
says:
Earlier versions of the database server supported only the IBM Informix extension
to the ANSI-SQL standard syntax for outer joins. This syntax is still supported.
However, the ANSI-SQL standard syntax provides for more flexibility with creating
queries. It is recommended that you use the ANSI-SQL standard syntax to create
new queries. Whichever form of syntax you use, you must use it for all outer joins
in a single query block.